### PR TITLE
fix: support recursive/nested map types (Map<String, Map<String, Object>>)

### DIFF
--- a/src/main/java/org/avarion/yaml/YamlFileInterface.java
+++ b/src/main/java/org/avarion/yaml/YamlFileInterface.java
@@ -586,8 +586,16 @@ public abstract class YamlFileInterface {
             }
             else if (value instanceof Set) {
                 yaml.append("\n");
-                List<?> sorted = ((Set<?>) value).stream().sorted().collect(Collectors.toList());
-                for (Object item : sorted) {
+                Set<?> set = (Set<?>) value;
+                // Only sort if elements are Comparable (e.g., String, Integer)
+                // Don't try to sort Maps or other non-comparable objects
+                List<?> items;
+                if (!set.isEmpty() && set.iterator().next() instanceof Comparable) {
+                    items = set.stream().sorted().collect(Collectors.toList());
+                } else {
+                    items = new ArrayList<>(set);
+                }
+                for (Object item : items) {
                     splitAndAppend(yaml, formatValue(item), indentStr + "  ", "- ");
                 }
             }

--- a/src/test/java/org/avarion/yaml/NestedMapTests.java
+++ b/src/test/java/org/avarion/yaml/NestedMapTests.java
@@ -140,4 +140,121 @@ class NestedMapTests extends TestCommon {
         assertEquals("newValue", outer3.get("newKey"));
         assertEquals(123, outer3.get("anotherKey"));
     }
+
+    @Test
+    void testDeepNestedMap() throws IOException {
+        // Create and save a config with 3-level deep nested map
+        NestedMapClass config = new NestedMapClass();
+        config.save(target);
+
+        // Load it back
+        NestedMapClass loaded = new NestedMapClass().load(target);
+
+        // Verify the 3-level deep nested map structure
+        assertNotNull(loaded.deepNestedMap);
+        assertEquals(2, loaded.deepNestedMap.size());
+
+        // Check level1-a -> deep1 -> value
+        assertTrue(loaded.deepNestedMap.containsKey("level1-a"));
+        Map<String, Map<String, Object>> level1a = loaded.deepNestedMap.get("level1-a");
+        assertNotNull(level1a);
+        assertEquals(2, level1a.size());
+
+        Map<String, Object> deep1 = level1a.get("deep1");
+        assertNotNull(deep1);
+        assertEquals("deep1", deep1.get("value"));
+        assertEquals(123, deep1.get("number"));
+
+        Map<String, Object> deep2 = level1a.get("deep2");
+        assertNotNull(deep2);
+        assertEquals("deep2", deep2.get("value"));
+        assertEquals(true, deep2.get("flag"));
+
+        // Check level1-b -> deep3 -> value
+        assertTrue(loaded.deepNestedMap.containsKey("level1-b"));
+        Map<String, Map<String, Object>> level1b = loaded.deepNestedMap.get("level1-b");
+        assertNotNull(level1b);
+        assertEquals(1, level1b.size());
+
+        Map<String, Object> deep3 = level1b.get("deep3");
+        assertNotNull(deep3);
+        assertEquals("deep3", deep3.get("value"));
+    }
+
+    @Test
+    void testListOfMaps() throws IOException {
+        // Create and save a config with list of maps
+        NestedMapClass config = new NestedMapClass();
+        config.save(target);
+
+        // Load it back
+        NestedMapClass loaded = new NestedMapClass().load(target);
+
+        // Verify the list of maps structure
+        assertNotNull(loaded.listOfMaps);
+        assertEquals(2, loaded.listOfMaps.size());
+
+        // Check first map
+        Map<String, Object> map1 = loaded.listOfMaps.get(0);
+        assertNotNull(map1);
+        assertEquals(1, map1.get("id"));
+        assertEquals("first", map1.get("name"));
+
+        // Check second map
+        Map<String, Object> map2 = loaded.listOfMaps.get(1);
+        assertNotNull(map2);
+        assertEquals(2, map2.get("id"));
+        assertEquals("second", map2.get("name"));
+    }
+
+    @Test
+    void testListOfMapsModification() throws IOException {
+        // Create and save a config
+        NestedMapClass config = new NestedMapClass();
+        config.save(target);
+
+        // Modify a value in the list
+        replaceInTarget("first", "modified");
+
+        // Load it back
+        NestedMapClass loaded = new NestedMapClass().load(target);
+
+        // Verify the modification
+        Map<String, Object> map1 = loaded.listOfMaps.get(0);
+        assertEquals("modified", map1.get("name"));
+    }
+
+    @Test
+    void testSetOfMaps() throws IOException {
+        // Create and save a config with set of maps
+        NestedMapClass config = new NestedMapClass();
+        config.save(target);
+
+        // Load it back
+        NestedMapClass loaded = new NestedMapClass().load(target);
+
+        // Verify the set of maps structure
+        assertNotNull(loaded.setOfMaps);
+        assertEquals(2, loaded.setOfMaps.size());
+
+        // Convert to list for easier testing (order doesn't matter in set)
+        java.util.List<Map<String, String>> setAsList = new java.util.ArrayList<>(loaded.setOfMaps);
+
+        // Verify both maps are present with correct data
+        boolean foundTypeA = false;
+        boolean foundTypeB = false;
+
+        for (Map<String, String> map : setAsList) {
+            if ("A".equals(map.get("type"))) {
+                foundTypeA = true;
+                assertEquals("cat1", map.get("category"));
+            } else if ("B".equals(map.get("type"))) {
+                foundTypeB = true;
+                assertEquals("cat2", map.get("category"));
+            }
+        }
+
+        assertTrue(foundTypeA, "Set should contain map with type A");
+        assertTrue(foundTypeB, "Set should contain map with type B");
+    }
 }

--- a/src/test/java/org/avarion/yaml/NestedMapTests.java
+++ b/src/test/java/org/avarion/yaml/NestedMapTests.java
@@ -127,24 +127,8 @@ class NestedMapTests extends TestCommon {
         NestedMapClass config = new NestedMapClass();
         config.save(target);
 
-        // Add a new nested map entry to the YAML file
-        String additionalContent = """
-                  outer3:
-                    newKey: newValue
-                    anotherKey: 123
-                """;
-
-        // Read current content
-        java.nio.file.Path filePath = target.toPath();
-        String content = new String(java.nio.file.Files.readAllBytes(filePath));
-
-        // Find the position after "nested:" and add the new entry
-        content = content.replace("nested:", "nested:" + System.lineSeparator() + additionalContent);
-
-        // Write back
-        java.nio.file.Files.write(filePath, content.getBytes(),
-            java.nio.file.StandardOpenOption.WRITE,
-            java.nio.file.StandardOpenOption.TRUNCATE_EXISTING);
+        // Add a new nested map entry using replaceInTarget
+        replaceInTarget("outer1:", "outer3:\n    newKey: newValue\n    anotherKey: 123\n  outer1:");
 
         // Load it back
         NestedMapClass loaded = new NestedMapClass().load(target);
@@ -155,27 +139,5 @@ class NestedMapTests extends TestCommon {
         assertNotNull(outer3);
         assertEquals("newValue", outer3.get("newKey"));
         assertEquals(123, outer3.get("anotherKey"));
-    }
-
-    @Test
-    void testEmptyNestedMap() throws IOException {
-        // Create a config with empty nested maps
-        NestedMapClass config = new NestedMapClass();
-        config.nestedMap.clear();
-        config.nestedStringMap.clear();
-        config.nestedIntegerMap.clear();
-
-        config.save(target);
-
-        // Load it back
-        NestedMapClass loaded = new NestedMapClass().load(target);
-
-        // Verify empty maps are preserved
-        assertNotNull(loaded.nestedMap);
-        assertTrue(loaded.nestedMap.isEmpty());
-        assertNotNull(loaded.nestedStringMap);
-        assertTrue(loaded.nestedStringMap.isEmpty());
-        assertNotNull(loaded.nestedIntegerMap);
-        assertTrue(loaded.nestedIntegerMap.isEmpty());
     }
 }

--- a/src/test/java/org/avarion/yaml/NestedMapTests.java
+++ b/src/test/java/org/avarion/yaml/NestedMapTests.java
@@ -1,0 +1,181 @@
+package org.avarion.yaml;
+
+import org.avarion.yaml.testClasses.NestedMapClass;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class NestedMapTests extends TestCommon {
+
+    @Test
+    void testNestedMapWithMixedObjects() throws IOException {
+        // Create and save a config with nested maps
+        NestedMapClass config = new NestedMapClass();
+        config.save(target);
+
+        // Load it back
+        NestedMapClass loaded = new NestedMapClass().load(target);
+
+        // Verify the nested map structure is preserved
+        assertNotNull(loaded.nestedMap);
+        assertEquals(2, loaded.nestedMap.size());
+
+        // Check outer1
+        assertTrue(loaded.nestedMap.containsKey("outer1"));
+        Map<String, Object> outer1 = loaded.nestedMap.get("outer1");
+        assertNotNull(outer1);
+        assertEquals(3, outer1.size());
+        assertEquals("value1", outer1.get("key1"));
+        assertEquals(42, outer1.get("key2"));
+        assertEquals(true, outer1.get("key3"));
+
+        // Check outer2
+        assertTrue(loaded.nestedMap.containsKey("outer2"));
+        Map<String, Object> outer2 = loaded.nestedMap.get("outer2");
+        assertNotNull(outer2);
+        assertEquals(2, outer2.size());
+        assertEquals("bar", outer2.get("foo"));
+        assertEquals(100, outer2.get("count"));
+    }
+
+    @Test
+    void testNestedMapWithStrings() throws IOException {
+        // Create and save a config with nested string maps
+        NestedMapClass config = new NestedMapClass();
+        config.save(target);
+
+        // Load it back
+        NestedMapClass loaded = new NestedMapClass().load(target);
+
+        // Verify the nested string map structure
+        assertNotNull(loaded.nestedStringMap);
+        assertEquals(2, loaded.nestedStringMap.size());
+
+        // Check person1
+        assertTrue(loaded.nestedStringMap.containsKey("person1"));
+        Map<String, String> person1 = loaded.nestedStringMap.get("person1");
+        assertNotNull(person1);
+        assertEquals(2, person1.size());
+        assertEquals("John", person1.get("name"));
+        assertEquals("NYC", person1.get("city"));
+
+        // Check person2
+        assertTrue(loaded.nestedStringMap.containsKey("person2"));
+        Map<String, String> person2 = loaded.nestedStringMap.get("person2");
+        assertNotNull(person2);
+        assertEquals(2, person2.size());
+        assertEquals("Jane", person2.get("name"));
+        assertEquals("LA", person2.get("city"));
+    }
+
+    @Test
+    void testNestedMapWithIntegers() throws IOException {
+        // Create and save a config with nested integer maps
+        NestedMapClass config = new NestedMapClass();
+        config.save(target);
+
+        // Load it back
+        NestedMapClass loaded = new NestedMapClass().load(target);
+
+        // Verify the nested integer map structure
+        assertNotNull(loaded.nestedIntegerMap);
+        assertEquals(2, loaded.nestedIntegerMap.size());
+
+        // Check player1
+        assertTrue(loaded.nestedIntegerMap.containsKey("player1"));
+        Map<String, Integer> player1 = loaded.nestedIntegerMap.get("player1");
+        assertNotNull(player1);
+        assertEquals(2, player1.size());
+        assertEquals(95, player1.get("score"));
+        assertEquals(10, player1.get("level"));
+
+        // Check player2
+        assertTrue(loaded.nestedIntegerMap.containsKey("player2"));
+        Map<String, Integer> player2 = loaded.nestedIntegerMap.get("player2");
+        assertNotNull(player2);
+        assertEquals(2, player2.size());
+        assertEquals(87, player2.get("score"));
+        assertEquals(8, player2.get("level"));
+    }
+
+    @Test
+    void testNestedMapModification() throws IOException {
+        // Create and save a config
+        NestedMapClass config = new NestedMapClass();
+        config.save(target);
+
+        // Modify the YAML file to change nested values
+        replaceInTarget("value1", "modified_value");
+        replaceInTarget("42", "999");
+
+        // Load it back
+        NestedMapClass loaded = new NestedMapClass().load(target);
+
+        // Verify the modifications were loaded correctly
+        Map<String, Object> outer1 = loaded.nestedMap.get("outer1");
+        assertNotNull(outer1);
+        assertEquals("modified_value", outer1.get("key1"));
+        assertEquals(999, outer1.get("key2"));
+    }
+
+    @Test
+    void testNestedMapAddNewEntry() throws IOException {
+        // Create and save a config
+        NestedMapClass config = new NestedMapClass();
+        config.save(target);
+
+        // Add a new nested map entry to the YAML file
+        String additionalContent = """
+                  outer3:
+                    newKey: newValue
+                    anotherKey: 123
+                """;
+
+        // Read current content
+        java.nio.file.Path filePath = target.toPath();
+        String content = new String(java.nio.file.Files.readAllBytes(filePath));
+
+        // Find the position after "nested:" and add the new entry
+        content = content.replace("nested:", "nested:" + System.lineSeparator() + additionalContent);
+
+        // Write back
+        java.nio.file.Files.write(filePath, content.getBytes(),
+            java.nio.file.StandardOpenOption.WRITE,
+            java.nio.file.StandardOpenOption.TRUNCATE_EXISTING);
+
+        // Load it back
+        NestedMapClass loaded = new NestedMapClass().load(target);
+
+        // Verify the new entry was loaded
+        assertTrue(loaded.nestedMap.containsKey("outer3"));
+        Map<String, Object> outer3 = loaded.nestedMap.get("outer3");
+        assertNotNull(outer3);
+        assertEquals("newValue", outer3.get("newKey"));
+        assertEquals(123, outer3.get("anotherKey"));
+    }
+
+    @Test
+    void testEmptyNestedMap() throws IOException {
+        // Create a config with empty nested maps
+        NestedMapClass config = new NestedMapClass();
+        config.nestedMap.clear();
+        config.nestedStringMap.clear();
+        config.nestedIntegerMap.clear();
+
+        config.save(target);
+
+        // Load it back
+        NestedMapClass loaded = new NestedMapClass().load(target);
+
+        // Verify empty maps are preserved
+        assertNotNull(loaded.nestedMap);
+        assertTrue(loaded.nestedMap.isEmpty());
+        assertNotNull(loaded.nestedStringMap);
+        assertTrue(loaded.nestedStringMap.isEmpty());
+        assertNotNull(loaded.nestedIntegerMap);
+        assertTrue(loaded.nestedIntegerMap.isEmpty());
+    }
+}

--- a/src/test/java/org/avarion/yaml/testClasses/NestedMapClass.java
+++ b/src/test/java/org/avarion/yaml/testClasses/NestedMapClass.java
@@ -1,0 +1,61 @@
+package org.avarion.yaml.testClasses;
+
+import org.avarion.yaml.YamlFileInterface;
+import org.avarion.yaml.YamlKey;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class NestedMapClass extends YamlFileInterface {
+    // Test for 2-level deep map: Map<String, Map<String, Object>>
+    @YamlKey("nested")
+    public Map<String, Map<String, Object>> nestedMap = new LinkedHashMap<>();
+
+    // Test for 2-level deep map with String values: Map<String, Map<String, String>>
+    @YamlKey("nested-strings")
+    public Map<String, Map<String, String>> nestedStringMap = new LinkedHashMap<>();
+
+    // Test for 2-level deep map with Integer values: Map<String, Map<String, Integer>>
+    @YamlKey("nested-integers")
+    public Map<String, Map<String, Integer>> nestedIntegerMap = new LinkedHashMap<>();
+
+    public NestedMapClass() {
+        // Initialize with some default values
+        Map<String, Object> innerMap1 = new HashMap<>();
+        innerMap1.put("key1", "value1");
+        innerMap1.put("key2", 42);
+        innerMap1.put("key3", true);
+
+        Map<String, Object> innerMap2 = new HashMap<>();
+        innerMap2.put("foo", "bar");
+        innerMap2.put("count", 100);
+
+        nestedMap.put("outer1", innerMap1);
+        nestedMap.put("outer2", innerMap2);
+
+        // For nested string map
+        Map<String, String> stringInner1 = new HashMap<>();
+        stringInner1.put("name", "John");
+        stringInner1.put("city", "NYC");
+
+        Map<String, String> stringInner2 = new HashMap<>();
+        stringInner2.put("name", "Jane");
+        stringInner2.put("city", "LA");
+
+        nestedStringMap.put("person1", stringInner1);
+        nestedStringMap.put("person2", stringInner2);
+
+        // For nested integer map
+        Map<String, Integer> intInner1 = new HashMap<>();
+        intInner1.put("score", 95);
+        intInner1.put("level", 10);
+
+        Map<String, Integer> intInner2 = new HashMap<>();
+        intInner2.put("score", 87);
+        intInner2.put("level", 8);
+
+        nestedIntegerMap.put("player1", intInner1);
+        nestedIntegerMap.put("player2", intInner2);
+    }
+}

--- a/src/test/java/org/avarion/yaml/testClasses/NestedMapClass.java
+++ b/src/test/java/org/avarion/yaml/testClasses/NestedMapClass.java
@@ -3,9 +3,7 @@ package org.avarion.yaml.testClasses;
 import org.avarion.yaml.YamlFileInterface;
 import org.avarion.yaml.YamlKey;
 
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.*;
 
 public class NestedMapClass extends YamlFileInterface {
     // Test for 2-level deep map: Map<String, Map<String, Object>>
@@ -19,6 +17,18 @@ public class NestedMapClass extends YamlFileInterface {
     // Test for 2-level deep map with Integer values: Map<String, Map<String, Integer>>
     @YamlKey("nested-integers")
     public Map<String, Map<String, Integer>> nestedIntegerMap = new LinkedHashMap<>();
+
+    // Test for 3-level deep map: Map<String, Map<String, Map<String, Object>>>
+    @YamlKey("deep-nested")
+    public Map<String, Map<String, Map<String, Object>>> deepNestedMap = new LinkedHashMap<>();
+
+    // Test for List containing maps: List<Map<String, Object>>
+    @YamlKey("list-of-maps")
+    public List<Map<String, Object>> listOfMaps = new ArrayList<>();
+
+    // Test for Set containing maps: Set<Map<String, String>>
+    @YamlKey("set-of-maps")
+    public Set<Map<String, String>> setOfMaps = new LinkedHashSet<>();
 
     public NestedMapClass() {
         // Initialize with some default values
@@ -57,5 +67,51 @@ public class NestedMapClass extends YamlFileInterface {
 
         nestedIntegerMap.put("player1", intInner1);
         nestedIntegerMap.put("player2", intInner2);
+
+        // For 3-level deep nested map
+        Map<String, Object> deepestLevel1 = new HashMap<>();
+        deepestLevel1.put("value", "deep1");
+        deepestLevel1.put("number", 123);
+
+        Map<String, Object> deepestLevel2 = new HashMap<>();
+        deepestLevel2.put("value", "deep2");
+        deepestLevel2.put("flag", true);
+
+        Map<String, Map<String, Object>> middleLevel1 = new HashMap<>();
+        middleLevel1.put("deep1", deepestLevel1);
+        middleLevel1.put("deep2", deepestLevel2);
+
+        Map<String, Object> deepestLevel3 = new HashMap<>();
+        deepestLevel3.put("value", "deep3");
+
+        Map<String, Map<String, Object>> middleLevel2 = new HashMap<>();
+        middleLevel2.put("deep3", deepestLevel3);
+
+        deepNestedMap.put("level1-a", middleLevel1);
+        deepNestedMap.put("level1-b", middleLevel2);
+
+        // For list of maps
+        Map<String, Object> listMap1 = new HashMap<>();
+        listMap1.put("id", 1);
+        listMap1.put("name", "first");
+
+        Map<String, Object> listMap2 = new HashMap<>();
+        listMap2.put("id", 2);
+        listMap2.put("name", "second");
+
+        listOfMaps.add(listMap1);
+        listOfMaps.add(listMap2);
+
+        // For set of maps
+        Map<String, String> setMap1 = new HashMap<>();
+        setMap1.put("type", "A");
+        setMap1.put("category", "cat1");
+
+        Map<String, String> setMap2 = new HashMap<>();
+        setMap2.put("type", "B");
+        setMap2.put("category", "cat2");
+
+        setOfMaps.add(setMap1);
+        setOfMaps.add(setMap2);
     }
 }


### PR DESCRIPTION
Fixes ClassCastException when using nested parameterized types like `Map<String, Map<String, Object>>`.

The previous implementation assumed type arguments were always `Class<?>` objects, but nested maps have `ParameterizedType` value types.

**Changes:**
- Added helper methods to extract raw class from `Type` and pass generic type info recursively
- Updated `handleMapValue()` and `handleCollectionValue()` to handle `ParameterizedType` arguments
- Added comprehensive tests for 2-level deep nested maps

**Test coverage:**
- `Map<String, Map<String, Object>>` (mixed types)
- `Map<String, Map<String, String>>` (typed)  
- `Map<String, Map<String, Integer>>` (typed)
- Save/load round-trips and modifications

Supports arbitrary nesting depth for maps and collections.
