### PR TITLE
feat: annotate record components and derive keys from identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ A simple, annotation-based YAML configuration library for Java. Built for Minecr
 - **Annotation-driven** - Define your config structure with simple annotations
 - **Type-safe** - Full support for primitives, collections, maps, enums, UUIDs, and Java Records
 - **Nested structures** - Use dot notation (`"database.host"`) for hierarchical configs
-- **Comments** - Add documentation directly in your YAML files
+- **Key naming** - Derive keys from field and record component names, in `snake_case` or verbatim
+- **Comments** - Add documentation directly in your YAML files, down to individual record components
 - **Leniency modes** - Strict or lenient type conversion
 - **Zero boilerplate** - No manual parsing or type casting
 
@@ -106,6 +107,27 @@ database:
   username: root
   password: secret
 ```
+
+Record components accept `@YamlComment` and `@YamlKey` too, so every key in the block can be
+documented and named independently:
+
+```java
+public record DatabaseConfig(
+        @YamlComment("Where the database lives") String host,
+        @YamlKey("PORT") int portNumber) {}
+```
+
+```yaml
+database:
+  # Where the database lives
+  host: localhost
+  PORT: 3306
+```
+
+Keys the library has to derive from a Java identifier — record components, and fields with a
+bare `@YamlKey` — are converted to `snake_case`, so `portNumber` would have become
+`port_number` had it not been named explicitly. Use `@YamlFile(naming = Naming.KEEP)` to keep
+identifiers exactly as written.
 
 ## Documentation
 

--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -24,6 +24,7 @@ public class MyConfig extends YamlFileInterface {
 | `header`   | `String`   | `""`           | Comment text that appears at the top of the YAML file        |
 | `fileName` | `String`   | `"config.yml"` | Default filename when using `load(plugin)` or `save(plugin)` |
 | `lenient`  | `Leniency` | `LENIENT`      | Default leniency mode for all fields                         |
+| `naming`   | `Naming`   | `SNAKE_CASE`   | How keys derived from a Java identifier are spelled          |
 
 ### Example with Header
 
@@ -55,6 +56,31 @@ Output:
 version: 1
 ```
 
+### Naming Strategy
+
+Keys that the library has to *derive* from a Java identifier are converted according to
+`naming`. Keys you spell out yourself in a `@YamlKey("...")` are never touched.
+
+```java
+@YamlFile(naming = Naming.KEEP)
+public class Config extends YamlFileInterface {
+    // ...
+}
+```
+
+| Strategy     | `modelId` becomes | Notes                                             |
+|--------------|-------------------|---------------------------------------------------|
+| `SNAKE_CASE` | `model_id`        | The default                                       |
+| `KEEP`       | `modelId`         | Use the identifier exactly as written             |
+
+Conversion is acronym-aware: `httpURL` becomes `http_url` and `getHTTPHeader` becomes
+`get_http_header`. A trailing digit stays attached to its word, so `modelId2` becomes
+`model_id2`.
+
+`SNAKE_CASE` is the default, so a config whose keys were previously derived (record
+components, and fields with a bare `@YamlKey`) changes spelling. Set `naming = Naming.KEEP`
+to keep the old file readable.
+
 ---
 
 ## @YamlKey
@@ -68,10 +94,36 @@ public String myField = "default";
 
 ### Attributes
 
-| Attribute | Type       | Default     | Description                                           |
-|-----------|------------|-------------|-------------------------------------------------------|
-| `value`   | `String`   | *required*  | The YAML key path (supports dot notation for nesting) |
-| `lenient` | `Leniency` | `UNDEFINED` | Leniency mode for this specific field                 |
+| Attribute | Type       | Default     | Description                                                       |
+|-----------|------------|-------------|--------------------------------------------------------------------|
+| `value`   | `String`   | `""`        | The YAML key path (supports dot notation for nesting). Empty means "derive it from the field name" |
+| `lenient` | `Leniency` | `UNDEFINED` | Leniency mode for this specific field                             |
+
+### Bare @YamlKey
+
+Leave the value off to key a field by its own name, run through the class's
+[naming strategy](#naming-strategy):
+
+```java
+public class Config extends YamlFileInterface {
+
+    @YamlKey
+    public String serverName = "Main";      // -> server_name
+
+    @YamlKey("max_players")
+    public int maxPlayers = 20;             // -> max_players, exactly as written
+
+    public String scratch = "not config";   // no annotation: never persisted
+}
+```
+
+```yaml
+server_name: Main
+max_players: 20
+```
+
+A field with no `@YamlKey` at all is still ignored entirely — the annotation is what marks a
+field as configuration, and leaving its value blank only delegates the *spelling* of the key.
 
 ### Dot Notation for Nested Keys
 
@@ -122,6 +174,34 @@ public class Config extends YamlFileInterface {
 }
 ```
 
+### On Record Components
+
+`@YamlKey` also works on the components of a record, where it renames a single key
+inside the record's block. This lets a record keep Java naming while the YAML keeps
+whatever convention the config already uses:
+
+```java
+public record AltarDefinition(
+        @YamlKey("modelID") int modelId,
+        int searchRadius,
+        String name) {}
+```
+
+```yaml
+altar:
+  modelID: 1001      # spelled out, so used verbatim
+  search_radius: 8   # derived, so converted
+  name: blood
+```
+
+Components without a `@YamlKey` have their key derived from the component name via the
+[naming strategy](#naming-strategy). The rename applies to reading as well, so the file
+round-trips.
+
+Dot notation is **not** supported here — a record component is one key inside the record's
+own block, so it cannot spread itself over a nested path. A `@YamlKey` containing a `.` on a
+record component throws an `IOException` on both save and load.
+
 ---
 
 ## @YamlComment
@@ -171,6 +251,43 @@ public class Config extends YamlFileInterface {
     public int maxConnections = 100;
 }
 ```
+
+### On Record Components
+
+Annotate a record's components to comment every key inside the record's block instead of
+only the block as a whole:
+
+```java
+public record DatabaseConfig(
+        @YamlComment("Host the database listens on") String host,
+        @YamlComment("Port, usually 3306 for MySQL") int port,
+        String database) {}
+
+public class Config extends YamlFileInterface {
+
+    @YamlComment("Database settings")
+    @YamlKey("database")
+    public DatabaseConfig database = new DatabaseConfig("localhost", 3306, "myapp");
+}
+```
+
+Output:
+
+```yaml
+# Database settings
+database:
+  # Host the database listens on
+  host: localhost
+  # Port, usually 3306 for MySQL
+  port: 3306
+  database: myapp
+```
+
+This works at every nesting level, so a record inside a record is commented too.
+
+Records used as **list items** are written without component comments — a list entry starts
+after its `-` with nowhere to put a comment, and repeating the same block for every item
+would only add noise.
 
 ---
 

--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -77,6 +77,12 @@ Conversion is acronym-aware: `httpURL` becomes `http_url` and `getHTTPHeader` be
 `get_http_header`. A trailing digit stays attached to its word, so `modelId2` becomes
 `model_id2`.
 
+> **Watch out for consecutive single capitals.** A run of capitals is kept together only when
+> a lowercase letter follows it, so `getHTTPHeader` splits sensibly but `allowPvP` becomes
+> `allow_pv_p` — each lone capital starts its own word. If that is not the key you want, spell
+> it out with `@YamlKey("allow_pvp")`, switch the class to `Naming.KEEP`, or name the
+> identifier `allowPvp` so there is only one boundary to find.
+
 `SNAKE_CASE` is the default, so a config whose keys were previously derived (record
 components, and fields with a bare `@YamlKey`) changes spelling. Set `naming = Naming.KEEP`
 to keep the old file readable.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -126,7 +126,7 @@ public record WorldSettings(
     String name,
     String generator,
     long seed,
-    boolean allowPvP,
+    boolean allowPvp,
     List<String> allowedGamemodes
 ) {}
 
@@ -193,8 +193,8 @@ worlds:
     name: world
     generator: default
     seed: 12345
-    allowPvP: true
-    allowedGamemodes:
+    allow_pvp: true
+    allowed_gamemodes:
       - SURVIVAL
       - ADVENTURE
 
@@ -203,8 +203,8 @@ worlds:
     name: creative
     generator: flat
     seed: 0
-    allowPvP: false
-    allowedGamemodes:
+    allow_pvp: false
+    allowed_gamemodes:
       - CREATIVE
 
 # Server spawn location
@@ -219,8 +219,8 @@ spawn:
 # Economy configuration
 economy:
   currency: coins
-  startingBalance: 100.0
-  maxBalance: 1000000.0
+  starting_balance: 100.0
+  max_balance: 1000000.0
   prices:
     diamond: 100.0
     emerald: 50.0

--- a/docs/records.md
+++ b/docs/records.md
@@ -33,6 +33,48 @@ server:
   port: 25565
 ```
 
+## Annotating Record Components
+
+`@YamlComment` and `@YamlKey` can be placed directly on a record's components, so a record
+behaves like the block of fields it replaces instead of collapsing to a single commented key.
+
+```java
+public record ServerInfo(
+        @YamlComment("Shown in the server list") String name,
+
+        @YamlComment("Address to bind to") String bindAddress,
+
+        @YamlKey("PORT") int port) {}
+
+public class Config extends YamlFileInterface {
+
+    @YamlComment("Main server")
+    @YamlKey("server")
+    public ServerInfo server = new ServerInfo("Main Server", "127.0.0.1", 25565);
+}
+```
+
+```yaml
+# Main server
+server:
+  # Shown in the server list
+  name: Main Server
+  # Address to bind to
+  bind_address: 127.0.0.1
+  PORT: 25565
+```
+
+- `@YamlComment` puts a comment above that one key, at every nesting level.
+- `@YamlKey` renames that one key, for both writing and reading, so the file round-trips.
+  Components without a `@YamlKey` have their key derived from the component name using the
+  class's [naming strategy](annotations.md#naming-strategy), which converts to `snake_case`
+  by default — hence `bindAddress` becoming `bind_address` above, while the spelled-out
+  `PORT` is left alone.
+- Dot notation is not supported on a record component — the key lives inside the record's own
+  block, so a value containing a `.` throws an `IOException`.
+- Records used as list items are written without component comments; a list entry has nowhere
+  to put them, and repeating them per item would only add noise.
+
 ## Nested Records
 
 Records can contain other records:
@@ -60,7 +102,7 @@ contact:
   address:
     street: 123 Main St
     city: Springfield
-    zipCode: 12345
+    zip_code: 12345
 ```
 
 ## Maps with Record Values
@@ -85,11 +127,11 @@ public class GameConfig extends YamlFileInterface {
 ```yaml
 players:
   player1:
-    displayName: Alice
+    display_name: Alice
     level: 50
     experience: 125000
   player2:
-    displayName: Bob
+    display_name: Bob
     level: 42
     experience: 98000
 ```
@@ -154,17 +196,17 @@ team:
       address:
         street: 123 St
         city: City A
-        zipCode: 11111
+        zip_code: 11111
     - name: Bob
       age: 35
       address:
         street: 456 Ave
         city: City B
-        zipCode: 22222
+        zip_code: 22222
   headquarters:
     street: 1 HQ Blvd
     city: Capital
-    zipCode: 10000
+    zip_code: 10000
 ```
 
 ## Records with Maps
@@ -289,14 +331,14 @@ database:
 # Cache configuration
 cache:
   enabled: true
-  ttlSeconds: 3600
-  maxSize: 1000
+  ttl_seconds: 3600
+  max_size: 1000
 
 # Web server settings
 server:
   name: MyApp Server
   port: 8080
-  allowedOrigins:
+  allowed_origins:
     - http://localhost:3000
     - https://myapp.com
 ```

--- a/src/main/java/org/avarion/yaml/Naming.java
+++ b/src/main/java/org/avarion/yaml/Naming.java
@@ -1,0 +1,48 @@
+package org.avarion.yaml;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+/**
+ * How a YAML key is spelled when it has to be <em>derived</em> from a Java identifier.
+ *
+ * <p>A key is derived for a record component without a {@link YamlKey}, and for a field or
+ * component carrying a bare {@code @YamlKey}. An explicit {@code @YamlKey("some.path")} is
+ * always used exactly as written and is never converted.</p>
+ *
+ * <pre>{@code
+ * @YamlFile(naming = Naming.KEEP)
+ * public class MyConfig extends YamlFileInterface {
+ *     // ...
+ * }
+ * }</pre>
+ */
+public enum Naming {
+    /** Use the Java identifier verbatim: {@code modelId} stays {@code modelId}. */
+    KEEP,
+
+    /** Split the identifier on word boundaries: {@code modelId} becomes {@code model_id}. */
+    SNAKE_CASE,
+    ;
+
+    /** {@code HTTPServer} -> {@code HTTP_Server}: the tail of an acronym starts a new word. */
+    private static final Pattern ACRONYM_BOUNDARY = Pattern.compile("([A-Z]+)([A-Z][a-z])");
+
+    /** {@code modelId} -> {@code model_Id}: a capital after a lowercase/digit starts a new word. */
+    private static final Pattern WORD_BOUNDARY = Pattern.compile("([a-z0-9])([A-Z])");
+
+    /**
+     * Spell {@code identifier} according to this strategy.
+     */
+    @NotNull String convert(final @NotNull String identifier) {
+        if (this == KEEP) {
+            return identifier;
+        }
+
+        String separated = ACRONYM_BOUNDARY.matcher(identifier).replaceAll("$1_$2");
+        separated = WORD_BOUNDARY.matcher(separated).replaceAll("$1_$2");
+        return separated.toLowerCase(Locale.ENGLISH);
+    }
+}

--- a/src/main/java/org/avarion/yaml/Naming.java
+++ b/src/main/java/org/avarion/yaml/Naming.java
@@ -41,6 +41,14 @@ public enum Naming {
             return identifier;
         }
 
+        // Both patterns need an ASCII capital to fire, so an identifier already equal to its own
+        // lowercasing has no boundary to split on and is its own answer. Single-word names are the
+        // common case, and String#toLowerCase hands back the very same instance when no character
+        // changes, so this costs a reference comparison rather than two Matcher allocations.
+        if (identifier.toLowerCase(Locale.ENGLISH).equals(identifier)) {
+            return identifier;
+        }
+
         String separated = ACRONYM_BOUNDARY.matcher(identifier).replaceAll("$1_$2");
         separated = WORD_BOUNDARY.matcher(separated).replaceAll("$1_$2");
         return separated.toLowerCase(Locale.ENGLISH);

--- a/src/main/java/org/avarion/yaml/RecordComponents.java
+++ b/src/main/java/org/avarion/yaml/RecordComponents.java
@@ -1,0 +1,62 @@
+package org.avarion.yaml;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.RecordComponent;
+import java.util.Arrays;
+
+/**
+ * Reads the YAML annotations off a record component.
+ *
+ * <p>{@link YamlKey} and {@link YamlComment} target fields, and the compiler propagates an
+ * annotation written on a record component onto that component's backing private final field.
+ * Reading the field is therefore the one lookup that works for every record, no matter which
+ * release of this library it was compiled against.</p>
+ */
+final class RecordComponents {
+
+    private RecordComponents() {
+        // Utility class
+    }
+
+    /**
+     * The YAML key for a component: its {@link YamlKey} when one is present and non-blank,
+     * otherwise the component name spelled according to {@code naming}.
+     *
+     * @throws IOException if the key contains a {@code .}; unlike a regular field, a record
+     *                     component cannot spread itself over a nested path.
+     */
+    static @NotNull String keyOf(final @NotNull RecordComponent component, final @NotNull Naming naming) throws IOException {
+        YamlKey annotation = annotationOn(component, YamlKey.class);
+        String key = annotation == null ? "" : annotation.value().trim();
+
+        if (key.isEmpty()) {
+            return naming.convert(component.getName());
+        }
+        if (key.indexOf('.') >= 0) {
+            throw new IOException("'" + key + "' cannot be used for record component '" + component.getName() + "' of "
+                                          + component.getDeclaringRecord().getSimpleName()
+                                          + ": a record component key cannot be nested, so it may not contain a '.'");
+        }
+        return key;
+    }
+
+    /**
+     * The {@link YamlComment} text for a component, or {@code null} when it has none.
+     */
+    static @Nullable String commentOf(final @NotNull RecordComponent component) {
+        YamlComment annotation = annotationOn(component, YamlComment.class);
+        return annotation == null ? null : annotation.value();
+    }
+
+    private static <A extends Annotation> @Nullable A annotationOn(final @NotNull RecordComponent component, final @NotNull Class<A> annotationType) {
+        return Arrays.stream(component.getDeclaringRecord().getDeclaredFields())
+                     .filter(field -> field.getName().equals(component.getName()))
+                     .findFirst()
+                     .map(field -> field.getAnnotation(annotationType))
+                     .orElse(null);
+    }
+}

--- a/src/main/java/org/avarion/yaml/TypeConverter.java
+++ b/src/main/java/org/avarion/yaml/TypeConverter.java
@@ -64,14 +64,16 @@ final class TypeConverter {
     /**
      * Convert a value to the type specified by the field.
      */
-    static @Nullable Object getConvertedValue(final @NotNull Field field, final Object value, boolean isLenient) throws IOException {
-        return getConvertedValue(field, field.getType(), value, isLenient);
+    static @Nullable Object getConvertedValue(final @NotNull Field field, final Object value, boolean isLenient, final @NotNull Naming naming)
+            throws IOException {
+        return getConvertedValue(field, field.getType(), value, isLenient, naming);
     }
 
     /**
      * Convert a value to the expected type with optional field context.
      */
-    static @Nullable Object getConvertedValue(final @Nullable Field field, final @NotNull Class<?> expectedType, final Object value, boolean isLenient)
+    static @Nullable Object getConvertedValue(
+            final @Nullable Field field, final @NotNull Class<?> expectedType, final Object value, boolean isLenient, final @NotNull Naming naming)
             throws IOException {
         if (value == null) {
             return handleNullValue(expectedType, field);
@@ -88,15 +90,15 @@ final class TypeConverter {
         }
 
         if (value instanceof List<?>) {
-            return handleCollectionValue(field, expectedType, (Collection<?>) value, isLenient);
+            return handleCollectionValue(field, expectedType, (Collection<?>) value, isLenient, naming);
         }
         if (Collection.class.isAssignableFrom(expectedType) && isLenient) {
             // We allow a single String/int/... to be assigned to a Collection -- but only when we're in lenient mode
-            return handleCollectionValue(field, expectedType, List.of(value), isLenient);
+            return handleCollectionValue(field, expectedType, List.of(value), isLenient, naming);
         }
 
         if (value instanceof Map && Map.class.isAssignableFrom(expectedType)) {
-            return handleMapValue(field, expectedType, (Map<?, ?>) value, isLenient);
+            return handleMapValue(field, expectedType, (Map<?, ?>) value, isLenient, naming);
         }
 
         if (expectedType.isInstance(value)) {
@@ -121,7 +123,7 @@ final class TypeConverter {
 
         // Handle Records: convert Map to Record using canonical constructor
         if (value instanceof Map && expectedType.isRecord()) {
-            return convertMapToRecord(expectedType, (Map<?, ?>) value, isLenient);
+            return convertMapToRecord(expectedType, (Map<?, ?>) value, isLenient, naming);
         }
 
         // For other classes, attempt to use their constructor that takes a String parameter
@@ -144,7 +146,8 @@ final class TypeConverter {
      * This method handles parameterized types (Maps/Collections with generic info).
      * For simple types, it delegates to getConvertedValue to avoid code duplication.
      */
-    static @Nullable Object convertWithType(final @NotNull Type type, final Object value, boolean isLenient) throws IOException {
+    static @Nullable Object convertWithType(final @NotNull Type type, final Object value, boolean isLenient, final @NotNull Naming naming)
+            throws IOException {
         Class<?> rawClass = getRawClass(type);
 
         if (value == null) {
@@ -165,8 +168,8 @@ final class TypeConverter {
             }
 
             for (Map.Entry<?, ?> entry : ((Map<?, ?>) value).entrySet()) {
-                Object convertedKey = convertWithType(keyType, entry.getKey(), isLenient);
-                Object convertedValue = convertWithType(valueType, entry.getValue(), isLenient);
+                Object convertedKey = convertWithType(keyType, entry.getKey(), isLenient, naming);
+                Object convertedValue = convertWithType(valueType, entry.getValue(), isLenient, naming);
                 if (convertedKey == LENIENT_ENUM_SKIP || convertedValue == LENIENT_ENUM_SKIP) {
                     continue;
                 }
@@ -187,7 +190,7 @@ final class TypeConverter {
             }
 
             for (Object item : (Collection<?>) value) {
-                Object convertedItem = convertWithType(elementType, item, isLenient);
+                Object convertedItem = convertWithType(elementType, item, isLenient, naming);
                 if (convertedItem == LENIENT_ENUM_SKIP) {
                     continue;
                 }
@@ -198,7 +201,7 @@ final class TypeConverter {
 
         // For all other types (primitives, String, enums, UUID, numbers, chars, etc.),
         // delegate to getConvertedValue which has all the conversion logic in one place.
-        return getConvertedValue(null, rawClass, value, isLenient);
+        return getConvertedValue(null, rawClass, value, isLenient, naming);
     }
 
     // ==================== Collection Handling ====================
@@ -207,7 +210,8 @@ final class TypeConverter {
      * Convert the incoming value into a Set/List/Queue.
      */
     private static @NotNull Object handleCollectionValue(
-            final @Nullable Field field, final @NotNull Class<?> expectedType, final @NotNull Collection<?> collection, boolean isLenient) throws IOException {
+            final @Nullable Field field, final @NotNull Class<?> expectedType, final @NotNull Collection<?> collection, boolean isLenient,
+            final @NotNull Naming naming) throws IOException {
 
         Collection<Object> result = createCollectionInstance(expectedType);
 
@@ -217,7 +221,7 @@ final class TypeConverter {
                 : Object.class;
 
         for (Object item : collection) {
-            Object convertedValue = convertWithType(elementType, item, isLenient);
+            Object convertedValue = convertWithType(elementType, item, isLenient, naming);
             if (convertedValue == LENIENT_ENUM_SKIP) {
                 continue;
             }
@@ -230,7 +234,8 @@ final class TypeConverter {
      * Convert the incoming value into a Map with properly typed keys and values.
      */
     private static @NotNull Object handleMapValue(
-            final @NotNull Field field, final @NotNull Class<?> expectedType, final Map<?, ?> map, boolean isLenient) throws IOException {
+            final @NotNull Field field, final @NotNull Class<?> expectedType, final Map<?, ?> map, boolean isLenient, final @NotNull Naming naming)
+            throws IOException {
 
         Map<Object, Object> result = new LinkedHashMap<>();
 
@@ -244,8 +249,8 @@ final class TypeConverter {
         }
 
         for (Map.Entry<?, ?> entry : map.entrySet()) {
-            Object convertedKey = convertWithType(keyType, entry.getKey(), isLenient);
-            Object convertedValue = convertWithType(valueType, entry.getValue(), isLenient);
+            Object convertedKey = convertWithType(keyType, entry.getKey(), isLenient, naming);
+            Object convertedValue = convertWithType(valueType, entry.getValue(), isLenient, naming);
             if (convertedKey == LENIENT_ENUM_SKIP || convertedValue == LENIENT_ENUM_SKIP) {
                 continue;
             }
@@ -268,12 +273,13 @@ final class TypeConverter {
     // ==================== Record Handling ====================
 
     /**
-     * Converts a Map to a Record instance by matching map keys to record component names.
+     * Converts a Map to a Record instance by matching map keys to record component names,
+     * or to the component's {@link YamlKey} when it carries one.
      * Supports nested records: if a component is itself a record and the value is a Map,
      * it will recursively convert the nested Map to the nested record type.
      */
-    private static @NotNull Object convertMapToRecord(final @NotNull Class<?> recordClass, final @NotNull Map<?, ?> map, boolean isLenient)
-            throws IOException {
+    private static @NotNull Object convertMapToRecord(
+            final @NotNull Class<?> recordClass, final @NotNull Map<?, ?> map, boolean isLenient, final @NotNull Naming naming) throws IOException {
         RecordComponent[] components = recordClass.getRecordComponents();
         Object[] args = new Object[components.length];
 
@@ -283,7 +289,7 @@ final class TypeConverter {
             Class<?> componentType = component.getType();
             Type genericType = component.getGenericType();
 
-            Object value = map.get(componentName);
+            Object value = map.get(RecordComponents.keyOf(component, naming));
 
             if (value == null) {
                 // Handle null: primitives cannot be null
@@ -295,19 +301,19 @@ final class TypeConverter {
             }
             else if (value instanceof Map && componentType.isRecord()) {
                 // Nested record: recursively convert
-                args[i] = convertMapToRecord(componentType, (Map<?, ?>) value, isLenient);
+                args[i] = convertMapToRecord(componentType, (Map<?, ?>) value, isLenient, naming);
             }
             else if (value instanceof Map && Map.class.isAssignableFrom(componentType)) {
                 // Map field within record: use convertWithType for proper type handling
-                args[i] = convertWithType(genericType, value, isLenient);
+                args[i] = convertWithType(genericType, value, isLenient, naming);
             }
             else if (value instanceof Collection && Collection.class.isAssignableFrom(componentType)) {
                 // Collection field within record: use convertWithType for proper type handling
-                args[i] = convertWithType(genericType, value, isLenient);
+                args[i] = convertWithType(genericType, value, isLenient, naming);
             }
             else {
                 // Regular field: use getConvertedValue for type coercion
-                args[i] = getConvertedValue(null, componentType, value, isLenient);
+                args[i] = getConvertedValue(null, componentType, value, isLenient, naming);
             }
 
             // A record component cannot be skipped, so a lenient enum-skip becomes null

--- a/src/main/java/org/avarion/yaml/YamlComment.java
+++ b/src/main/java/org/avarion/yaml/YamlComment.java
@@ -18,6 +18,13 @@ import java.lang.annotation.Target;
  *     private int serverPort = 8080;
  * }
  * }</pre>
+ *
+ * <p>It can also be placed on a record component, where it comments that single key inside the
+ * record's block rather than the block as a whole:</p>
+ *
+ * <pre>{@code
+ * public record ServerInfo(@YamlComment("The port number to listen on") int port) {}
+ * }</pre>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD})

--- a/src/main/java/org/avarion/yaml/YamlFile.java
+++ b/src/main/java/org/avarion/yaml/YamlFile.java
@@ -27,4 +27,10 @@ public @interface YamlFile {
 	@NotNull String header() default "";
     Leniency lenient() default Leniency.LENIENT;
     @NotNull String fileName() default "config.yml";
+
+    /**
+     * How keys that have to be derived from a Java identifier are spelled.
+     * An explicit {@code @YamlKey("...")} is never converted.
+     */
+    @NotNull Naming naming() default Naming.SNAKE_CASE;
 }

--- a/src/main/java/org/avarion/yaml/YamlFileInterface.java
+++ b/src/main/java/org/avarion/yaml/YamlFileInterface.java
@@ -23,7 +23,6 @@ import java.util.function.Consumer;
 public abstract class YamlFileInterface {
     static final Object UNKNOWN = new Object();
     private static final YamlWrapper yaml = YamlWrapperFactory.create();
-    private static final YamlWriter yamlWriter = new YamlWriter(yaml);
 
     // ==================== Load Methods ====================
 
@@ -58,7 +57,7 @@ public abstract class YamlFileInterface {
         boolean isLenientByDefault = yamlFileAnnotation == null || yamlFileAnnotation.lenient() != Leniency.STRICT;
 
         try {
-            loadFields(data, isLenientByDefault);
+            loadFields(data, isLenientByDefault, namingOf(yamlFileAnnotation));
         } catch (IllegalAccessException | IllegalArgumentException | NullPointerException | FinalAttribute e) {
             throw new IOException(e);
         }
@@ -219,7 +218,8 @@ public abstract class YamlFileInterface {
 
     // ==================== Field Processing ====================
 
-    private void loadFields(Map<String, Object> data, boolean isLenientByDefault) throws FinalAttribute, IllegalAccessException, IOException {
+    private void loadFields(Map<String, Object> data, boolean isLenientByDefault, @NotNull Naming naming)
+            throws FinalAttribute, IllegalAccessException, IOException {
         if (data == null) {
             data = new HashMap<>();
         }
@@ -228,25 +228,26 @@ public abstract class YamlFileInterface {
             for (Field field : clazz.getDeclaredFields()) {
                 YamlKey keyAnnotation = field.getAnnotation(YamlKey.class);
 
-                if (keyAnnotation != null && !keyAnnotation.value().trim().isEmpty()) {
-                    readYamlKeyField(data, field, keyAnnotation, isLenientByDefault);
+                if (keyAnnotation != null) {
+                    readYamlKeyField(data, field, keyAnnotation, isLenientByDefault, naming);
                 }
             }
         }
     }
 
-    private void readYamlKeyField(Map<String, Object> data, @NotNull Field field, @NotNull YamlKey annotation, boolean isLenientByDefault)
+    private void readYamlKeyField(
+            Map<String, Object> data, @NotNull Field field, @NotNull YamlKey annotation, boolean isLenientByDefault, @NotNull Naming naming)
             throws FinalAttribute, IllegalAccessException, IOException {
         if (Modifier.isFinal(field.getModifiers())) {
             throw new FinalAttribute(field.getName());
         }
 
-        String key = annotation.value();
+        String key = keyOf(field, annotation, naming);
         boolean isLenient = isLenient(annotation.lenient(), isLenientByDefault);
 
         Object value = getNestedValue(data, key.split("\\."));
         if (value != UNKNOWN) {
-            Object converted = TypeConverter.getConvertedValue(field, value, isLenient);
+            Object converted = TypeConverter.getConvertedValue(field, value, isLenient, naming);
             if (converted == TypeConverter.LENIENT_ENUM_SKIP) {
                 // Lenient mode: bad enum value at top level — leave field at its default
                 return;
@@ -271,11 +272,12 @@ public abstract class YamlFileInterface {
         }
 
         // Fields
+        Naming naming = namingOf(yamlFileAnnotation);
         NestedMap nestedMap = new NestedMap();
         for (Field field : clazz.getDeclaredFields()) {
             YamlKey keyAnnotation = field.getAnnotation(YamlKey.class);
 
-            if (keyAnnotation != null && !keyAnnotation.value().trim().isEmpty()) {
+            if (keyAnnotation != null) {
                 if (Modifier.isFinal(field.getModifiers())) {
                     throw new FinalAttribute(field.getName());
                 }
@@ -284,14 +286,28 @@ public abstract class YamlFileInterface {
                 Object value = field.get(this);
                 YamlComment comment = field.getAnnotation(YamlComment.class);
 
-                nestedMap.put(keyAnnotation.value(), comment == null ? null : comment.value(), value);
+                nestedMap.put(keyOf(field, keyAnnotation, naming), comment == null ? null : comment.value(), value);
             }
         }
 
         // Convert the nested map to YAML using YamlWriter
-        result.append(yamlWriter.write(nestedMap.getMap()));
+        result.append(new YamlWriter(yaml, naming).write(nestedMap.getMap()));
 
         return result.toString();
+    }
+
+    /**
+     * The YAML key for a field: its {@link YamlKey} when one is spelled out, otherwise the
+     * field's own name run through the naming strategy.
+     */
+    private static @NotNull String keyOf(final @NotNull Field field, final @NotNull YamlKey annotation, final @NotNull Naming naming) {
+        String key = annotation.value().trim();
+        return key.isEmpty() ? naming.convert(field.getName()) : key;
+    }
+
+    /** The naming strategy of a config class, falling back to the annotation's own default. */
+    private static @NotNull Naming namingOf(final @Nullable YamlFile annotation) {
+        return annotation == null ? Naming.SNAKE_CASE : annotation.naming();
     }
 
     private void appendHeaderComment(StringBuilder result, String header) {

--- a/src/main/java/org/avarion/yaml/YamlKey.java
+++ b/src/main/java/org/avarion/yaml/YamlKey.java
@@ -15,6 +15,14 @@ import java.lang.annotation.Target;
  *     private String databaseUrl;
  * }
  * }</pre>
+ *
+ * <p>It can also be placed on a record component to rename that single key inside the record's
+ * block. Dot notation is not supported there: the key lives inside the record's own block and
+ * cannot be nested any further.</p>
+ *
+ * <pre>{@code
+ * public record ServerInfo(@YamlKey("bind_port") int port) {}
+ * }</pre>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD})

--- a/src/main/java/org/avarion/yaml/YamlWriter.java
+++ b/src/main/java/org/avarion/yaml/YamlWriter.java
@@ -27,6 +27,9 @@ class YamlWriter {
 
     private final YamlWrapper yamlWrapper;
 
+    /** How keys derived from a record component's name are spelled. */
+    private final Naming naming;
+
     /** Reflectively load a class by name, returning {@code null} when it's not on the classpath. */
     static @Nullable Class<?> loadOptional(@NotNull String className) {
         try {
@@ -62,7 +65,7 @@ class YamlWriter {
      */
     public String write(Map<Object, Object> nestedMap) throws IOException {
         StringBuilder result = new StringBuilder();
-        writeValue(result, nestedMap, "", "");
+        writeValue(result, nestedMap, "", "", true);
         return result.toString();
     }
 
@@ -70,14 +73,14 @@ class YamlWriter {
      * SINGLE DISPATCHER: Decides what type to write (Map, Collection, or scalar)
      * This is the ONLY place where we check the type of a value.
      */
-    private void writeValue(StringBuilder yaml, Object value, String firstIndent, String indent) throws IOException {
+    private void writeValue(StringBuilder yaml, Object value, String firstIndent, String indent, boolean withComments) throws IOException {
         // Handle Records: convert to Map for YAML representation
         if (value != null && value.getClass().isRecord()) {
             value = recordToMap(value);
         }
 
         if (value instanceof Map) {
-            writeMap(yaml, (Map<?, ?>) value, firstIndent, indent);
+            writeMap(yaml, (Map<?, ?>) value, firstIndent, indent, withComments);
         }
         else if (value instanceof Collection) {
             writeCollection(yaml, (Collection<?>) value, indent);
@@ -90,7 +93,7 @@ class YamlWriter {
     /**
      * Primitive building block: Write a Map
      */
-    private void writeMap(StringBuilder yaml, @NotNull Map<?, ?> map, String firstIndent, String indent) throws IOException {
+    private void writeMap(StringBuilder yaml, @NotNull Map<?, ?> map, String firstIndent, String indent, boolean withComments) throws IOException {
         boolean firstEntry = true;
         for (Map.Entry<?, ?> entry : map.entrySet()) {
             Object key = entry.getKey();
@@ -98,14 +101,16 @@ class YamlWriter {
 
             // Handle comments from NestedNode
             if (value instanceof NestedMap.NestedNode node) {
-                appendComment(yaml, node.comment, indent);
+                if (withComments) {
+                    appendComment(yaml, node.comment, indent);
+                }
                 value = node.value;
             }
             yaml.append(firstEntry ? firstIndent:indent);
             firstEntry = false;
 
             yaml.append(key).append(":\n");
-            writeValue(yaml, value, indent + "  ", indent + "  ");
+            writeValue(yaml, value, indent + "  ", indent + "  ", withComments);
         }
     }
 
@@ -133,7 +138,9 @@ class YamlWriter {
                 yaml.append(indent);
             }
             yaml.append("- ");
-            writeValue(yaml, item, "", indent + "  ");
+            // A list item starts mid-line, right after the dash, so there is nowhere to put a
+            // comment; repeating the same record comments for every item would be noise anyway.
+            writeValue(yaml, item, "", indent + "  ", false);
         }
     }
 
@@ -154,6 +161,8 @@ class YamlWriter {
     /**
      * Converts a Record to a Map by extracting all component values.
      * Handles nested records by recursively converting them to Maps.
+     * Each value is wrapped in a {@link NestedMap.NestedNode} so a component's
+     * {@link YamlComment} travels with it, and the key honours its {@link YamlKey}.
      */
     private Map<String, Object> recordToMap(@NotNull Object potentialRecord) throws IOException {
         Map<String, Object> result = new LinkedHashMap<>();
@@ -171,7 +180,7 @@ class YamlWriter {
                     value = recordToMap(value);
                 }
 
-                result.put(name, value);
+                result.put(RecordComponents.keyOf(component, naming), new NestedMap.NestedNode(value, RecordComponents.commentOf(component)));
             }
             catch (IllegalAccessException | InvocationTargetException e) {
                 throw new IOException("Failed to access record component '" + name + "': " + e.getMessage(), e);

--- a/src/test/java/org/avarion/yaml/AltarRecordTests.java
+++ b/src/test/java/org/avarion/yaml/AltarRecordTests.java
@@ -87,7 +87,7 @@ class AltarRecordTests extends TestCommon {
         assertTrue(yaml.contains("blood:"), "Should have blood altar");
         assertTrue(yaml.contains("light:"), "Should have light altar");
         assertTrue(yaml.contains("name:"), "Should have name field");
-        assertTrue(yaml.contains("displayName:"), "Should have displayName field");
+        assertTrue(yaml.contains("display_name:"), "Should have display_name field");
         assertTrue(yaml.contains("lore:"), "Should have lore field");
         assertTrue(yaml.contains("material:"), "Should have material field");
         assertTrue(yaml.contains("ingredients:"), "Should have ingredients field");
@@ -102,14 +102,14 @@ class AltarRecordTests extends TestCommon {
                 altars:
                   blood:
                     name: blood
-                    displayName: '&4Blood Altar'
+                    display_name: '&4Blood Altar'
                     lore:
                       - '&7A dark altar'
                       - '&7for blood rituals'
                     material: ENCHANTING_TABLE
-                    modelId: 1001
-                    targetItemName: blood_essence
-                    targetItemAmount: 1
+                    model_id: 1001
+                    target_item_name: blood_essence
+                    target_item_amount: 1
                     ingredients:
                       REDSTONE: 16
                       GHAST_TEAR: 1

--- a/src/test/java/org/avarion/yaml/BareKeyTests.java
+++ b/src/test/java/org/avarion/yaml/BareKeyTests.java
@@ -1,0 +1,58 @@
+package org.avarion.yaml;
+
+import org.avarion.yaml.testClasses.BareKeyClass;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for a bare {@link YamlKey}, which persists the field under its own name.
+ */
+class BareKeyTests extends TestCommon {
+
+    @Test
+    void testBareKeyDerivesTheKeyFromTheFieldName() throws IOException {
+        new BareKeyClass().save(target);
+
+        // serverName is derived (and so converted); max_players was spelled out and is used as-is.
+        assertEquals("""
+                # Uses the field name as its key
+                server_name: Main
+                max_players: 20
+                debug: false
+                """, readFile());
+    }
+
+    @Test
+    void testBareKeyRoundTrips() throws IOException {
+        BareKeyClass config = new BareKeyClass();
+        config.serverName = "Renamed";
+        config.maxPlayers = 100;
+        config.debug = true;
+        config.save(target);
+
+        BareKeyClass loaded = new BareKeyClass().load(target);
+
+        assertEquals("Renamed", loaded.serverName);
+        assertEquals(100, loaded.maxPlayers);
+        assertEquals(true, loaded.debug);
+    }
+
+    @Test
+    void testFieldWithoutAnnotationIsStillSkipped() throws IOException {
+        writeYaml("""
+                server_name: FromFile
+                max_players: 5
+                debug: true
+                notPersisted: FromFile
+                """);
+
+        BareKeyClass loaded = new BareKeyClass().load(target);
+
+        assertEquals("FromFile", loaded.serverName);
+        // No @YamlKey at all still means "not part of the configuration".
+        assertEquals("ignored", loaded.notPersisted);
+    }
+}

--- a/src/test/java/org/avarion/yaml/NamingTests.java
+++ b/src/test/java/org/avarion/yaml/NamingTests.java
@@ -1,0 +1,144 @@
+package org.avarion.yaml;
+
+import org.avarion.yaml.testClasses.KeepNamingClass;
+import org.avarion.yaml.testClasses.NamingRecord;
+import org.avarion.yaml.testClasses.SnakeCaseNamingClass;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for {@link Naming}, the strategy used for keys that are derived from a Java identifier.
+ */
+class NamingTests extends TestCommon {
+
+    // ===== The conversion itself =====
+
+    @ParameterizedTest
+    @CsvSource({
+            "modelId,       model_id",
+            "modelId2,      model_id2",
+            "httpURL,       http_url",
+            "getHTTPHeader, get_http_header",
+            "name,          name",
+            "name1,         name1",
+            "already_snake, already_snake",
+            "URL,           url",
+    })
+    void testSnakeCaseConversion(String identifier, String expected) {
+        assertEquals(expected, Naming.SNAKE_CASE.convert(identifier));
+    }
+
+    @ParameterizedTest
+    @CsvSource({"modelId", "modelId2", "httpURL", "name", "already_snake"})
+    void testKeepConversionIsTheIdentity(String identifier) {
+        assertEquals(identifier, Naming.KEEP.convert(identifier));
+    }
+
+    // ===== Derived keys follow the strategy =====
+
+    @Test
+    void testSnakeCaseIsTheDefaultForDerivedKeys() throws IOException {
+        new SnakeCaseNamingClass().save(target);
+
+        assertEquals("""
+                derived_block:
+                  model_id: a
+                  model_id2: b
+                  http_url: c
+                  name: d
+                  someCamelKey: e
+                anExplicitFieldKey: kept
+                """, readFile());
+    }
+
+    @Test
+    void testKeepLeavesDerivedKeysAlone() throws IOException {
+        new KeepNamingClass().save(target);
+
+        assertEquals("""
+                derivedBlock:
+                  modelId: a
+                  modelId2: b
+                  httpURL: c
+                  name: d
+                  someCamelKey: e
+                anExplicitFieldKey: kept
+                """, readFile());
+    }
+
+    // ===== An explicit key is never converted, under either strategy =====
+
+    @Test
+    void testExplicitKeysStayVerbatimUnderSnakeCase() throws IOException {
+        new SnakeCaseNamingClass().save(target);
+
+        String yaml = readFile();
+        assertEquals(true, yaml.contains("  someCamelKey: e\n"), yaml);
+        assertEquals(true, yaml.contains("anExplicitFieldKey: kept\n"), yaml);
+    }
+
+    @Test
+    void testExplicitKeysStayVerbatimUnderKeep() throws IOException {
+        new KeepNamingClass().save(target);
+
+        String yaml = readFile();
+        assertEquals(true, yaml.contains("  someCamelKey: e\n"), yaml);
+        assertEquals(true, yaml.contains("anExplicitFieldKey: kept\n"), yaml);
+    }
+
+    // ===== Reader and writer agree =====
+
+    @Test
+    void testSnakeCaseRoundTrips() throws IOException {
+        SnakeCaseNamingClass config = new SnakeCaseNamingClass();
+        config.derivedBlock = new NamingRecord("1", "2", "3", "4", "5");
+        config.explicitField = "changed";
+        config.save(target);
+
+        SnakeCaseNamingClass loaded = new SnakeCaseNamingClass();
+        loaded.derivedBlock = null;
+        loaded.load(target);
+
+        // Would fail if only the writer converted: the reader would look up 'modelId' and find nothing.
+        assertEquals(new NamingRecord("1", "2", "3", "4", "5"), loaded.derivedBlock);
+        assertEquals("changed", loaded.explicitField);
+    }
+
+    @Test
+    void testKeepRoundTrips() throws IOException {
+        KeepNamingClass config = new KeepNamingClass();
+        config.derivedBlock = new NamingRecord("1", "2", "3", "4", "5");
+        config.save(target);
+
+        KeepNamingClass loaded = new KeepNamingClass();
+        loaded.derivedBlock = null;
+        loaded.load(target);
+
+        assertEquals(new NamingRecord("1", "2", "3", "4", "5"), loaded.derivedBlock);
+    }
+
+    @Test
+    void testKeepDoesNotAnswerToConvertedComponentKeys() throws IOException {
+        // The block itself is found, but its components are spelled the SNAKE_CASE way.
+        writeYaml("""
+                derivedBlock:
+                  model_id: a
+                  model_id2: b
+                  http_url: c
+                  name: d
+                  someCamelKey: e
+                """);
+
+        KeepNamingClass loaded = new KeepNamingClass();
+        loaded.load(target);
+
+        // Under KEEP only 'name' (single word, so unaffected by conversion) and the explicitly
+        // named key still line up; the converted spellings are not recognised.
+        assertEquals(new NamingRecord(null, null, null, "d", "e"), loaded.derivedBlock);
+    }
+}

--- a/src/test/java/org/avarion/yaml/NamingTests.java
+++ b/src/test/java/org/avarion/yaml/NamingTests.java
@@ -28,6 +28,8 @@ class NamingTests extends TestCommon {
             "name1,         name1",
             "already_snake, already_snake",
             "URL,           url",
+            // Consecutive single capitals each start a word. Documented as a sharp edge.
+            "allowPvP,      allow_pv_p",
     })
     void testSnakeCaseConversion(String identifier, String expected) {
         assertEquals(expected, Naming.SNAKE_CASE.convert(identifier));

--- a/src/test/java/org/avarion/yaml/RecordAnnotationTests.java
+++ b/src/test/java/org/avarion/yaml/RecordAnnotationTests.java
@@ -1,0 +1,202 @@
+package org.avarion.yaml;
+
+import org.avarion.yaml.testClasses.*;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link YamlComment} and {@link YamlKey} placed on record components.
+ */
+class RecordAnnotationTests extends TestCommon {
+
+    // ===== @YamlComment on record components =====
+
+    @Test
+    void testCommentsAreWrittenPerRecordComponent() throws IOException {
+        CommentedRecordClass config = new CommentedRecordClass();
+        config.save(target);
+
+        assertTrue(readFile().startsWith("""
+                # Home address
+                address:
+                  # Street name and number
+                  street: 123 Main St
+                  # City the address is in.
+                  # Used for the delivery zone.
+                  city: Springfield
+                  zip_code: 12345
+                """), "Each component should get its own comment:\n" + readFile());
+    }
+
+    @Test
+    void testCommentsAreWrittenAtEveryNestingLevel() throws IOException {
+        CommentedRecordClass config = new CommentedRecordClass();
+        config.save(target);
+
+        assertTrue(readFile().contains("""
+                person:
+                  # Full name
+                  name: John Doe
+                  # Age in years
+                  age: 30
+                  # Where this person lives
+                  address:
+                    # Street name and number
+                    street: 456 Work St
+                    # City the address is in.
+                    # Used for the delivery zone.
+                    city: Shelbyville
+                    zip_code: 67890
+                """), "Nested records should be commented too:\n" + readFile());
+    }
+
+    @Test
+    void testCommentsAreSuppressedInsideCollections() throws IOException {
+        CommentedRecordClass config = new CommentedRecordClass();
+        config.save(target);
+
+        assertTrue(readFile().endsWith("""
+                previous-addresses:
+                  - street: 1 Old Rd
+                    city: Ogdenville
+                    zip_code: 11111
+                  - street: 2 Older Rd
+                    city: North Haverbrook
+                    zip_code: 22222
+                """), "List items should stay comment-free:\n" + readFile());
+    }
+
+    @Test
+    void testCommentedRecordRoundTrip() throws IOException {
+        new CommentedRecordClass().save(target);
+
+        CommentedRecordClass loaded = new CommentedRecordClass();
+        loaded.address = null;
+        loaded.person = null;
+        loaded.previousAddresses.clear();
+        loaded.load(target);
+
+        assertEquals(new CommentedAddress("123 Main St", "Springfield", 12345), loaded.address);
+        assertEquals(new CommentedPerson("John Doe", 30, new CommentedAddress("456 Work St", "Shelbyville", 67890)), loaded.person);
+        assertEquals(List.of(new CommentedAddress("1 Old Rd", "Ogdenville", 11111),
+                             new CommentedAddress("2 Older Rd", "North Haverbrook", 22222)), loaded.previousAddresses);
+    }
+
+    // ===== Backwards compatibility =====
+
+    /**
+     * {@link SimpleRecordClass} is pinned to {@link Naming#KEEP}, the escape hatch for configs
+     * written before the naming strategy existed: its output stays byte-for-byte identical.
+     */
+    @Test
+    void testKeepNamingReproducesTheOriginalSpellingByteForByte() throws IOException {
+        new SimpleRecordClass().save(target);
+
+        assertEquals("""
+                address:
+                  street: 123 Main St
+                  city: Springfield
+                  zipCode: 12345
+                person:
+                  name: John Doe
+                  age: 30
+                  address:
+                    street: 456 Work St
+                    city: Shelbyville
+                    zipCode: 67890
+                """, readFile());
+    }
+
+    // ===== @YamlKey on record components =====
+
+    @Test
+    void testYamlKeyRenamesRecordComponents() throws IOException {
+        new RenamedRecordClass().save(target);
+
+        assertEquals("""
+                # Database settings
+                database:
+                  # Host the database listens on
+                  host_name: localhost
+                  port: 5432
+                  # Credentials used to connect
+                  login:
+                    # Login user
+                    user_name: admin
+                    pass_word: secret
+                """, readFile());
+    }
+
+    @Test
+    void testRenamedRecordRoundTrip() throws IOException {
+        new RenamedRecordClass().save(target);
+
+        RenamedRecordClass loaded = new RenamedRecordClass();
+        loaded.database = null;
+        loaded.load(target);
+
+        assertEquals(new RenamedDatabase("localhost", 5432, new RenamedCredentials("admin", "secret")), loaded.database);
+    }
+
+    @Test
+    void testRenamedRecordLoadsFromHandWrittenYaml() throws IOException {
+        writeYaml("""
+                database:
+                  host_name: db.example.com
+                  port: 3306
+                  login:
+                    user_name: root
+                    pass_word: hunter2
+                """);
+
+        RenamedRecordClass loaded = new RenamedRecordClass();
+        loaded.load(target);
+
+        assertEquals(new RenamedDatabase("db.example.com", 3306, new RenamedCredentials("root", "hunter2")), loaded.database);
+    }
+
+    @Test
+    void testComponentNameIsIgnoredOnceRenamed() throws IOException {
+        writeYaml("""
+                database:
+                  hostName: db.example.com
+                  port: 3306
+                  credentials:
+                    userName: root
+                    passWord: hunter2
+                """);
+
+        RenamedRecordClass loaded = new RenamedRecordClass();
+        loaded.load(target);
+
+        // 'port' still loads by component name; the renamed ones no longer answer to it.
+        assertEquals(new RenamedDatabase(null, 3306, null), loaded.database);
+    }
+
+    // ===== Unsupported dotted keys =====
+
+    @Test
+    void testDottedComponentKeyIsRejectedWhenSaving() {
+        DottedKeyClass config = new DottedKeyClass();
+
+        IOException error = assertThrows(IOException.class, () -> config.save(target));
+        assertTrue(error.getMessage().contains("nested.value"), error.getMessage());
+    }
+
+    @Test
+    void testDottedComponentKeyIsRejectedWhenLoading() throws IOException {
+        writeYaml("""
+                holder:
+                  value: something
+                """);
+
+        DottedKeyClass loaded = new DottedKeyClass();
+
+        IOException error = assertThrows(IOException.class, () -> loaded.load(target));
+        assertTrue(error.getMessage().contains("nested.value"), error.getMessage());
+    }
+}

--- a/src/test/java/org/avarion/yaml/TypeConverterDirectTest.java
+++ b/src/test/java/org/avarion/yaml/TypeConverterDirectTest.java
@@ -22,35 +22,35 @@ class TypeConverterDirectTest {
     @Test
     void testObjectTypeWithMapValueReturnsAsIs() throws IOException {
         Map<String, Object> mapValue = Map.of("key", "value");
-        Object result = TypeConverter.getConvertedValue(null, Object.class, mapValue, false);
+        Object result = TypeConverter.getConvertedValue(null, Object.class, mapValue, false, Naming.SNAKE_CASE);
         assertSame(mapValue, result);
     }
 
     @Test
     void testObjectTypeWithCollectionValueReturnsAsIs() throws IOException {
         List<String> listValue = List.of("a", "b");
-        Object result = TypeConverter.getConvertedValue(null, Object.class, listValue, false);
+        Object result = TypeConverter.getConvertedValue(null, Object.class, listValue, false, Naming.SNAKE_CASE);
         assertSame(listValue, result);
     }
 
     @Test
     void testObjectTypeWithScalarValueDoesNotReturnAsIs() throws IOException {
         // Object.class + non-collection/non-map → should fall through to isInstance check
-        Object result = TypeConverter.getConvertedValue(null, Object.class, "hello", false);
+        Object result = TypeConverter.getConvertedValue(null, Object.class, "hello", false, Naming.SNAKE_CASE);
         assertEquals("hello", result);
     }
 
     @Test
     void testNullValueForPrimitiveWithoutFieldThrowsWithoutFieldName() {
         IOException thrown = assertThrows(IOException.class, () ->
-                TypeConverter.getConvertedValue(null, int.class, null, false));
+                TypeConverter.getConvertedValue(null, int.class, null, false, Naming.SNAKE_CASE));
         assertEquals("Cannot assign null to primitive type int", thrown.getMessage());
         assertFalse(thrown.getMessage().contains("field:"));
     }
 
     @Test
     void testNullValueForNonPrimitiveReturnsNull() throws IOException {
-        Object result = TypeConverter.getConvertedValue(null, String.class, null, false);
+        Object result = TypeConverter.getConvertedValue(null, String.class, null, false, Naming.SNAKE_CASE);
         assertNull(result);
     }
 
@@ -58,7 +58,7 @@ class TypeConverterDirectTest {
     void testEnumTypeWithNonStringValueFallsThrough() {
         // Enum type but value is Integer → should fall through enum check, hit Number check, then throw
         IOException thrown = assertThrows(IOException.class, () ->
-                TypeConverter.getConvertedValue(null, Material.class, 42, false));
+                TypeConverter.getConvertedValue(null, Material.class, 42, false, Naming.SNAKE_CASE));
         assertTrue(thrown.getMessage().contains("Cannot convert Integer to Material"));
     }
 
@@ -67,7 +67,7 @@ class TypeConverterDirectTest {
         // value is Map but expectedType is not Map and not Record → falls through to constructor/field attempts
         Map<String, Object> mapValue = Map.of("key", "value");
         IOException thrown = assertThrows(IOException.class, () ->
-                TypeConverter.getConvertedValue(null, Integer.class, mapValue, false));
+                TypeConverter.getConvertedValue(null, Integer.class, mapValue, false, Naming.SNAKE_CASE));
         assertTrue(thrown.getMessage().contains("I cannot figure out how to retrieve this type"));
     }
 
@@ -75,7 +75,7 @@ class TypeConverterDirectTest {
     void testStringValueWithNonUuidExpectedType() throws IOException {
         // String value with non-UUID expectedType → should not enter UUID branch
         // String for a String field → isInstance returns true
-        Object result = TypeConverter.getConvertedValue(null, String.class, "hello", false);
+        Object result = TypeConverter.getConvertedValue(null, String.class, "hello", false, Naming.SNAKE_CASE);
         assertEquals("hello", result);
     }
 
@@ -83,20 +83,20 @@ class TypeConverterDirectTest {
     void testNonStringValueWithUuidExpectedType() {
         // Non-string value for UUID type → skip UUID branch, skip boolean, hit Number, throw
         IOException thrown = assertThrows(IOException.class, () ->
-                TypeConverter.getConvertedValue(null, UUID.class, 42, false));
+                TypeConverter.getConvertedValue(null, UUID.class, 42, false, Naming.SNAKE_CASE));
         assertTrue(thrown.getMessage().contains("Cannot convert"));
     }
 
     @Test
     void testBooleanConversionFromBooleanObject() throws IOException {
         // Direct Boolean value → convertToBoolean returns as-is
-        Object result = TypeConverter.getConvertedValue(null, Boolean.class, Boolean.TRUE, false);
+        Object result = TypeConverter.getConvertedValue(null, Boolean.class, Boolean.TRUE, false, Naming.SNAKE_CASE);
         assertEquals(Boolean.TRUE, result);
     }
 
     @Test
     void testBooleanConversionFromStringNo() throws IOException {
-        Object result = TypeConverter.getConvertedValue(null, boolean.class, "no", false);
+        Object result = TypeConverter.getConvertedValue(null, boolean.class, "no", false, Naming.SNAKE_CASE);
         assertEquals(Boolean.FALSE, result);
     }
 
@@ -104,14 +104,14 @@ class TypeConverterDirectTest {
     void testCollectionWithLenientFalseDoesNotConvertSingleValue() {
         // Single String value, Collection expectedType, but NOT lenient → should fall through
         IOException thrown = assertThrows(IOException.class, () ->
-                TypeConverter.getConvertedValue(null, List.class, "single", false));
+                TypeConverter.getConvertedValue(null, List.class, "single", false, Naming.SNAKE_CASE));
         assertTrue(thrown.getMessage().contains("I cannot figure out how to retrieve this type"));
     }
 
     @Test
     void testCollectionWithLenientTrueConvertsSingleValue() throws IOException {
         // Single String value, Collection expectedType, lenient → wraps in List
-        Object result = TypeConverter.getConvertedValue(null, List.class, "single", true);
+        Object result = TypeConverter.getConvertedValue(null, List.class, "single", true, Naming.SNAKE_CASE);
         assertInstanceOf(List.class, result);
         assertEquals(List.of("single"), result);
     }
@@ -121,13 +121,13 @@ class TypeConverterDirectTest {
     @Test
     void testConvertWithTypeNullForPrimitiveThrows() {
         IOException thrown = assertThrows(IOException.class, () ->
-                TypeConverter.convertWithType(int.class, null, false));
+                TypeConverter.convertWithType(int.class, null, false, Naming.SNAKE_CASE));
         assertEquals("Cannot assign null to primitive type int", thrown.getMessage());
     }
 
     @Test
     void testConvertWithTypeNullForNonPrimitiveReturnsNull() throws IOException {
-        Object result = TypeConverter.convertWithType(String.class, null, false);
+        Object result = TypeConverter.convertWithType(String.class, null, false, Naming.SNAKE_CASE);
         assertNull(result);
     }
 
@@ -136,7 +136,7 @@ class TypeConverterDirectTest {
         // Map value with raw Map.class type (no parameterized type info)
         Map<String, Object> mapValue = new LinkedHashMap<>();
         mapValue.put("key", "value");
-        Object result = TypeConverter.convertWithType(Map.class, mapValue, false);
+        Object result = TypeConverter.convertWithType(Map.class, mapValue, false, Naming.SNAKE_CASE);
         assertInstanceOf(Map.class, result);
     }
 
@@ -144,13 +144,13 @@ class TypeConverterDirectTest {
     void testConvertWithTypeCollectionWithRawClass() throws IOException {
         // Collection value with raw List.class type (no parameterized type info)
         List<String> listValue = List.of("a", "b");
-        Object result = TypeConverter.convertWithType(List.class, listValue, false);
+        Object result = TypeConverter.convertWithType(List.class, listValue, false, Naming.SNAKE_CASE);
         assertInstanceOf(List.class, result);
     }
 
     @Test
     void testConvertWithTypeScalar() throws IOException {
-        Object result = TypeConverter.convertWithType(String.class, "hello", false);
+        Object result = TypeConverter.convertWithType(String.class, "hello", false, Naming.SNAKE_CASE);
         assertEquals("hello", result);
     }
 
@@ -166,7 +166,7 @@ class TypeConverterDirectTest {
     void testHandleCollectionValueWithRawListField() throws Exception {
         // Raw List field (no parameterized type) — element type falls through to Object.
         java.lang.reflect.Field rawList = RawFieldFixture.class.getField("rawList");
-        Object result = TypeConverter.getConvertedValue(rawList, List.class, List.of("a", "b"), false);
+        Object result = TypeConverter.getConvertedValue(rawList, List.class, List.of("a", "b"), false, Naming.SNAKE_CASE);
         assertEquals(List.of("a", "b"), result);
     }
 
@@ -176,7 +176,7 @@ class TypeConverterDirectTest {
         java.lang.reflect.Field rawMap = RawFieldFixture.class.getField("rawMap");
         Map<String, String> input = new LinkedHashMap<>();
         input.put("k", "v");
-        Object result = TypeConverter.getConvertedValue(rawMap, Map.class, input, false);
+        Object result = TypeConverter.getConvertedValue(rawMap, Map.class, input, false, Naming.SNAKE_CASE);
         assertEquals(input, result);
     }
 
@@ -283,10 +283,10 @@ class TypeConverterDirectTest {
         Map<String, Object> recordMap = new LinkedHashMap<>();
         recordMap.put("street", "123 Main St");
         recordMap.put("city", "Springfield");
-        recordMap.put("zipCode", null); // int cannot be null
+        recordMap.put("zip_code", null); // int cannot be null
 
         IOException thrown = assertThrows(IOException.class, () ->
-                TypeConverter.getConvertedValue(null, Address.class, recordMap, false));
+                TypeConverter.getConvertedValue(null, Address.class, recordMap, false, Naming.SNAKE_CASE));
         assertTrue(thrown.getMessage().contains("Cannot assign null to primitive record component 'zipCode'"));
     }
 
@@ -303,7 +303,7 @@ class TypeConverterDirectTest {
         recordMap.put("name", "Student");
         recordMap.put("scores", innerMap);
 
-        Object result = TypeConverter.getConvertedValue(null, RecordWithMap.class, recordMap, false);
+        Object result = TypeConverter.getConvertedValue(null, RecordWithMap.class, recordMap, false, Naming.SNAKE_CASE);
         assertInstanceOf(RecordWithMap.class, result);
         RecordWithMap converted = (RecordWithMap) result;
         assertEquals("Student", converted.name());
@@ -319,7 +319,7 @@ class TypeConverterDirectTest {
         recordMap.put("name", "Item");
         recordMap.put("tags", tags);
 
-        Object result = TypeConverter.getConvertedValue(null, RecordWithList.class, recordMap, false);
+        Object result = TypeConverter.getConvertedValue(null, RecordWithList.class, recordMap, false, Naming.SNAKE_CASE);
         assertInstanceOf(RecordWithList.class, result);
         RecordWithList converted = (RecordWithList) result;
         assertEquals("Item", converted.name());
@@ -332,34 +332,34 @@ class TypeConverterDirectTest {
     void testNumberToUnsupportedTypeThrows() {
         // Number value but expectedType is not a numeric type
         IOException thrown = assertThrows(IOException.class, () ->
-                TypeConverter.getConvertedValue(null, UUID.class, 42, false));
+                TypeConverter.getConvertedValue(null, UUID.class, 42, false, Naming.SNAKE_CASE));
         assertTrue(thrown.getMessage().contains("Cannot convert Integer to UUID"));
     }
 
     @Test
     void testFloatConversionLenientAllowsPrecisionLoss() throws IOException {
         // Double that can't be exactly represented as float, but lenient mode allows it
-        Object result = TypeConverter.getConvertedValue(null, float.class, 1.234567890123, true);
+        Object result = TypeConverter.getConvertedValue(null, float.class, 1.234567890123, true, Naming.SNAKE_CASE);
         assertInstanceOf(Float.class, result);
     }
 
     @Test
     void testFloatConversionStrictRejectsPrecisionLoss() {
         IOException thrown = assertThrows(IOException.class, () ->
-                TypeConverter.getConvertedValue(null, float.class, 1.234567890123, false));
+                TypeConverter.getConvertedValue(null, float.class, 1.234567890123, false, Naming.SNAKE_CASE));
         assertTrue(thrown.getMessage().contains("cannot be precisely represented as a float"));
     }
 
     @Test
     void testCharacterConversionLenientTakesFirstChar() throws IOException {
-        Object result = TypeConverter.getConvertedValue(null, char.class, "abc", true);
+        Object result = TypeConverter.getConvertedValue(null, char.class, "abc", true, Naming.SNAKE_CASE);
         assertEquals('a', result);
     }
 
     @Test
     void testCharacterConversionStrictRejectsMultiChar() {
         IOException thrown = assertThrows(IOException.class, () ->
-                TypeConverter.getConvertedValue(null, char.class, "abc", false));
+                TypeConverter.getConvertedValue(null, char.class, "abc", false, Naming.SNAKE_CASE));
         assertTrue(thrown.getMessage().contains("Cannot convert String of length 3 to Character"));
     }
 
@@ -368,37 +368,37 @@ class TypeConverterDirectTest {
     @Test
     void testDoubleToIntegerConversion() throws IOException {
         // Double value being converted to Integer.class → hits the Integer.class branch in convertToNumber
-        Object result = TypeConverter.getConvertedValue(null, Integer.class, 42.0, false);
+        Object result = TypeConverter.getConvertedValue(null, Integer.class, 42.0, false, Naming.SNAKE_CASE);
         assertEquals(42, result);
     }
 
     @Test
     void testDoubleToLongConversion() throws IOException {
-        Object result = TypeConverter.getConvertedValue(null, Long.class, 42.0, false);
+        Object result = TypeConverter.getConvertedValue(null, Long.class, 42.0, false, Naming.SNAKE_CASE);
         assertEquals(42L, result);
     }
 
     @Test
     void testDoubleToShortConversion() throws IOException {
-        Object result = TypeConverter.getConvertedValue(null, Short.class, 42.0, false);
+        Object result = TypeConverter.getConvertedValue(null, Short.class, 42.0, false, Naming.SNAKE_CASE);
         assertEquals((short) 42, result);
     }
 
     @Test
     void testDoubleToByteConversion() throws IOException {
-        Object result = TypeConverter.getConvertedValue(null, Byte.class, 42.0, false);
+        Object result = TypeConverter.getConvertedValue(null, Byte.class, 42.0, false, Naming.SNAKE_CASE);
         assertEquals((byte) 42, result);
     }
 
     @Test
     void testIntToDoubleConversion() throws IOException {
-        Object result = TypeConverter.getConvertedValue(null, Double.class, 42, false);
+        Object result = TypeConverter.getConvertedValue(null, Double.class, 42, false, Naming.SNAKE_CASE);
         assertEquals(42.0, result);
     }
 
     @Test
     void testIntToFloatConversion() throws IOException {
-        Object result = TypeConverter.getConvertedValue(null, Float.class, 42, false);
+        Object result = TypeConverter.getConvertedValue(null, Float.class, 42, false, Naming.SNAKE_CASE);
         assertEquals(42.0f, result);
     }
 
@@ -428,7 +428,7 @@ class TypeConverterDirectTest {
         mapValue.put("key1", 10);
         mapValue.put("key2", 20);
 
-        Object result = TypeConverter.convertWithType(mapType, mapValue, false);
+        Object result = TypeConverter.convertWithType(mapType, mapValue, false, Naming.SNAKE_CASE);
         assertInstanceOf(Map.class, result);
         Map<?, ?> resultMap = (Map<?, ?>) result;
         assertEquals(10, resultMap.get("key1"));
@@ -455,7 +455,7 @@ class TypeConverterDirectTest {
         };
 
         List<String> listValue = List.of("a", "b");
-        Object result = TypeConverter.convertWithType(listType, listValue, false);
+        Object result = TypeConverter.convertWithType(listType, listValue, false, Naming.SNAKE_CASE);
         assertInstanceOf(List.class, result);
         assertEquals(2, ((List<?>) result).size());
     }
@@ -485,7 +485,7 @@ class TypeConverterDirectTest {
         Map<String, Object> mapValue = new LinkedHashMap<>();
         mapValue.put("key", "value");
 
-        Object result = TypeConverter.convertWithType(rawMapType, mapValue, false);
+        Object result = TypeConverter.convertWithType(rawMapType, mapValue, false, Naming.SNAKE_CASE);
         assertInstanceOf(Map.class, result);
     }
 
@@ -509,7 +509,7 @@ class TypeConverterDirectTest {
         };
 
         List<String> listValue = List.of("a", "b");
-        Object result = TypeConverter.convertWithType(rawListType, listValue, false);
+        Object result = TypeConverter.convertWithType(rawListType, listValue, false, Naming.SNAKE_CASE);
         assertInstanceOf(List.class, result);
     }
 
@@ -536,7 +536,7 @@ class TypeConverterDirectTest {
         Map<String, Object> mapValue = new LinkedHashMap<>();
         mapValue.put("key", "value");
 
-        Object result = TypeConverter.convertWithType(singleArgMapType, mapValue, false);
+        Object result = TypeConverter.convertWithType(singleArgMapType, mapValue, false, Naming.SNAKE_CASE);
         assertInstanceOf(Map.class, result);
     }
 
@@ -550,7 +550,7 @@ class TypeConverterDirectTest {
         recordMap.put("value", -1);
 
         IOException thrown = assertThrows(IOException.class, () ->
-                TypeConverter.getConvertedValue(null, ValidatingRecord.class, recordMap, false));
+                TypeConverter.getConvertedValue(null, ValidatingRecord.class, recordMap, false, Naming.SNAKE_CASE));
         assertTrue(thrown.getMessage().contains("Failed to instantiate record ValidatingRecord"));
     }
 
@@ -558,15 +558,15 @@ class TypeConverterDirectTest {
 
     @Test
     void testRecordComponentGetsMapValueButExpectsString() throws IOException {
-        // Address has String street, String city, int zipCode
+        // Address has String street, String city, int zipCode (keyed zip_code in YAML)
         // Provide a Map where a String is expected → falls through else-if chain to else block
         Map<String, Object> recordMap = new LinkedHashMap<>();
         recordMap.put("street", Map.of("nested", "value")); // Map for a String component
         recordMap.put("city", "Springfield");
-        recordMap.put("zipCode", 12345);
+        recordMap.put("zip_code", 12345);
 
         // String has a String(String) constructor, so Map.toString() will be used
-        Object result = TypeConverter.getConvertedValue(null, Address.class, recordMap, false);
+        Object result = TypeConverter.getConvertedValue(null, Address.class, recordMap, false, Naming.SNAKE_CASE);
         assertInstanceOf(Address.class, result);
         // The map's toString becomes the street value
         Address addr = (Address) result;
@@ -582,10 +582,10 @@ class TypeConverterDirectTest {
         Map<String, Object> recordMap = new LinkedHashMap<>();
         recordMap.put("street", List.of("a", "b")); // List for a String component
         recordMap.put("city", "Springfield");
-        recordMap.put("zipCode", 12345);
+        recordMap.put("zip_code", 12345);
 
         // Falls through to else block, then getConvertedValue tries to create String collection → fails
         assertThrows(IOException.class, () ->
-                TypeConverter.getConvertedValue(null, Address.class, recordMap, false));
+                TypeConverter.getConvertedValue(null, Address.class, recordMap, false, Naming.SNAKE_CASE));
     }
 }

--- a/src/test/java/org/avarion/yaml/YamlFileInterfaceTest.java
+++ b/src/test/java/org/avarion/yaml/YamlFileInterfaceTest.java
@@ -64,7 +64,9 @@ class YamlFileInterfaceTest extends TestCommon {
 
         NullOrEmptyKey loaded = new NullOrEmptyKey().load(target);
 
-        assertEquals("A", loaded.name1);
+        // An empty @YamlKey derives its key from the field name, so name1 is persisted.
+        assertEquals("1", loaded.name1);
+        // No @YamlKey at all is still never persisted, so name2 falls back to its default.
         assertEquals("B", loaded.name2);
         assertEquals("3", loaded.name3);
     }

--- a/src/test/java/org/avarion/yaml/testClasses/BareKeyClass.java
+++ b/src/test/java/org/avarion/yaml/testClasses/BareKeyClass.java
@@ -1,0 +1,24 @@
+package org.avarion.yaml.testClasses;
+
+import org.avarion.yaml.YamlComment;
+import org.avarion.yaml.YamlFileInterface;
+import org.avarion.yaml.YamlKey;
+
+/**
+ * Test class mixing a bare {@link YamlKey} (key taken from the field name), an explicitly
+ * named key, and a field with no annotation at all (never persisted).
+ */
+public class BareKeyClass extends YamlFileInterface {
+
+    @YamlComment("Uses the field name as its key")
+    @YamlKey
+    public String serverName = "Main";
+
+    @YamlKey("max_players")
+    public int maxPlayers = 20;
+
+    @YamlKey("")
+    public boolean debug = false;
+
+    public String notPersisted = "ignored";
+}

--- a/src/test/java/org/avarion/yaml/testClasses/CommentedAddress.java
+++ b/src/test/java/org/avarion/yaml/testClasses/CommentedAddress.java
@@ -1,0 +1,19 @@
+package org.avarion.yaml.testClasses;
+
+import org.avarion.yaml.YamlComment;
+import org.avarion.yaml.YamlKey;
+
+/**
+ * A record whose components carry {@link YamlComment} annotations.
+ * {@code zipCode} deliberately has no comment, and an empty {@link YamlKey} that must fall
+ * back to the component name.
+ */
+public record CommentedAddress(
+        @YamlComment("Street name and number") String street,
+
+        @YamlComment("""
+                City the address is in.
+                Used for the delivery zone.""") String city,
+
+        @YamlKey("") int zipCode) {
+}

--- a/src/test/java/org/avarion/yaml/testClasses/CommentedPerson.java
+++ b/src/test/java/org/avarion/yaml/testClasses/CommentedPerson.java
@@ -1,0 +1,15 @@
+package org.avarion.yaml.testClasses;
+
+import org.avarion.yaml.YamlComment;
+
+/**
+ * A record with commented components, one of which is itself a record with commented
+ * components. Used to verify comments are emitted at every nesting level.
+ */
+public record CommentedPerson(
+        @YamlComment("Full name") String name,
+
+        @YamlComment("Age in years") int age,
+
+        @YamlComment("Where this person lives") CommentedAddress address) {
+}

--- a/src/test/java/org/avarion/yaml/testClasses/CommentedRecordClass.java
+++ b/src/test/java/org/avarion/yaml/testClasses/CommentedRecordClass.java
@@ -1,0 +1,29 @@
+package org.avarion.yaml.testClasses;
+
+import org.avarion.yaml.YamlComment;
+import org.avarion.yaml.YamlFileInterface;
+import org.avarion.yaml.YamlKey;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Test class holding records whose components are annotated with {@link YamlComment}.
+ */
+public class CommentedRecordClass extends YamlFileInterface {
+
+    @YamlComment("Home address")
+    @YamlKey("address")
+    public CommentedAddress address = new CommentedAddress("123 Main St", "Springfield", 12345);
+
+    @YamlKey("person")
+    public CommentedPerson person = new CommentedPerson("John Doe", 30, new CommentedAddress("456 Work St", "Shelbyville", 67890));
+
+    @YamlKey("previous-addresses")
+    public List<CommentedAddress> previousAddresses = new ArrayList<>();
+
+    public CommentedRecordClass() {
+        previousAddresses.add(new CommentedAddress("1 Old Rd", "Ogdenville", 11111));
+        previousAddresses.add(new CommentedAddress("2 Older Rd", "North Haverbrook", 22222));
+    }
+}

--- a/src/test/java/org/avarion/yaml/testClasses/DottedKeyClass.java
+++ b/src/test/java/org/avarion/yaml/testClasses/DottedKeyClass.java
@@ -1,0 +1,13 @@
+package org.avarion.yaml.testClasses;
+
+import org.avarion.yaml.YamlFileInterface;
+import org.avarion.yaml.YamlKey;
+
+/**
+ * Test class holding a record with an unsupported dotted component key.
+ */
+public class DottedKeyClass extends YamlFileInterface {
+
+    @YamlKey("holder")
+    public DottedKeyRecord holder = new DottedKeyRecord("something");
+}

--- a/src/test/java/org/avarion/yaml/testClasses/DottedKeyRecord.java
+++ b/src/test/java/org/avarion/yaml/testClasses/DottedKeyRecord.java
@@ -1,0 +1,9 @@
+package org.avarion.yaml.testClasses;
+
+import org.avarion.yaml.YamlKey;
+
+/**
+ * A record whose component asks for a nested (dotted) key, which is not supported.
+ */
+public record DottedKeyRecord(@YamlKey("nested.value") String value) {
+}

--- a/src/test/java/org/avarion/yaml/testClasses/KeepNamingClass.java
+++ b/src/test/java/org/avarion/yaml/testClasses/KeepNamingClass.java
@@ -1,0 +1,19 @@
+package org.avarion.yaml.testClasses;
+
+import org.avarion.yaml.Naming;
+import org.avarion.yaml.YamlFile;
+import org.avarion.yaml.YamlFileInterface;
+import org.avarion.yaml.YamlKey;
+
+/**
+ * The same shape as {@link SnakeCaseNamingClass}, but opted out of key conversion.
+ */
+@YamlFile(naming = Naming.KEEP)
+public class KeepNamingClass extends YamlFileInterface {
+
+    @YamlKey
+    public NamingRecord derivedBlock = NamingRecord.sample();
+
+    @YamlKey("anExplicitFieldKey")
+    public String explicitField = "kept";
+}

--- a/src/test/java/org/avarion/yaml/testClasses/NamingRecord.java
+++ b/src/test/java/org/avarion/yaml/testClasses/NamingRecord.java
@@ -1,0 +1,23 @@
+package org.avarion.yaml.testClasses;
+
+import org.avarion.yaml.YamlKey;
+
+/**
+ * A record covering the naming edge cases: plain camelCase, a trailing digit, an embedded
+ * acronym, a single word, and a component that names its own key explicitly in camelCase.
+ */
+public record NamingRecord(
+        String modelId,
+
+        String modelId2,
+
+        String httpURL,
+
+        String name,
+
+        @YamlKey("someCamelKey") String explicit) {
+
+    public static NamingRecord sample() {
+        return new NamingRecord("a", "b", "c", "d", "e");
+    }
+}

--- a/src/test/java/org/avarion/yaml/testClasses/RenamedCredentials.java
+++ b/src/test/java/org/avarion/yaml/testClasses/RenamedCredentials.java
@@ -1,0 +1,13 @@
+package org.avarion.yaml.testClasses;
+
+import org.avarion.yaml.YamlComment;
+import org.avarion.yaml.YamlKey;
+
+/**
+ * A nested record whose components are renamed to snake_case via {@link YamlKey}.
+ */
+public record RenamedCredentials(
+        @YamlKey("user_name") @YamlComment("Login user") String userName,
+
+        @YamlKey("pass_word") String passWord) {
+}

--- a/src/test/java/org/avarion/yaml/testClasses/RenamedDatabase.java
+++ b/src/test/java/org/avarion/yaml/testClasses/RenamedDatabase.java
@@ -1,0 +1,15 @@
+package org.avarion.yaml.testClasses;
+
+import org.avarion.yaml.YamlComment;
+import org.avarion.yaml.YamlKey;
+
+/**
+ * A record mixing renamed and un-renamed components; {@code port} keeps its component name.
+ */
+public record RenamedDatabase(
+        @YamlKey("host_name") @YamlComment("Host the database listens on") String hostName,
+
+        int port,
+
+        @YamlKey("login") @YamlComment("Credentials used to connect") RenamedCredentials credentials) {
+}

--- a/src/test/java/org/avarion/yaml/testClasses/RenamedRecordClass.java
+++ b/src/test/java/org/avarion/yaml/testClasses/RenamedRecordClass.java
@@ -1,0 +1,15 @@
+package org.avarion.yaml.testClasses;
+
+import org.avarion.yaml.YamlComment;
+import org.avarion.yaml.YamlFileInterface;
+import org.avarion.yaml.YamlKey;
+
+/**
+ * Test class holding a record whose components are renamed via {@link YamlKey}.
+ */
+public class RenamedRecordClass extends YamlFileInterface {
+
+    @YamlComment("Database settings")
+    @YamlKey("database")
+    public RenamedDatabase database = new RenamedDatabase("localhost", 5432, new RenamedCredentials("admin", "secret"));
+}

--- a/src/test/java/org/avarion/yaml/testClasses/SimpleRecordClass.java
+++ b/src/test/java/org/avarion/yaml/testClasses/SimpleRecordClass.java
@@ -1,11 +1,16 @@
 package org.avarion.yaml.testClasses;
 
+import org.avarion.yaml.Naming;
+import org.avarion.yaml.YamlFile;
 import org.avarion.yaml.YamlFileInterface;
 import org.avarion.yaml.YamlKey;
 
 /**
  * Test class for simple record field serialization/deserialization.
+ * Pinned to {@link Naming#KEEP} so it keeps guarding the pre-naming-strategy spelling
+ * ({@code zipCode} rather than {@code zip_code}).
  */
+@YamlFile(naming = Naming.KEEP)
 public class SimpleRecordClass extends YamlFileInterface {
 
     @YamlKey("address")

--- a/src/test/java/org/avarion/yaml/testClasses/SnakeCaseNamingClass.java
+++ b/src/test/java/org/avarion/yaml/testClasses/SnakeCaseNamingClass.java
@@ -1,0 +1,17 @@
+package org.avarion.yaml.testClasses;
+
+import org.avarion.yaml.YamlFileInterface;
+import org.avarion.yaml.YamlKey;
+
+/**
+ * Config using the default naming strategy (SNAKE_CASE), with an explicitly named
+ * camelCase field key that must survive untouched.
+ */
+public class SnakeCaseNamingClass extends YamlFileInterface {
+
+    @YamlKey
+    public NamingRecord derivedBlock = NamingRecord.sample();
+
+    @YamlKey("anExplicitFieldKey")
+    public String explicitField = "kept";
+}


### PR DESCRIPTION
## Motivation

A record used as a config field could only carry a single `@YamlComment` for its entire block, and its keys were always the raw component names. That makes records strictly worse than the flat fields they replace: you can document `database.host` but not `host` inside a `DatabaseConfig` record.

```yaml
# Database settings          <- the only comment you could write
database:
  host: localhost
  port: 3306
```

## What changed

**`@YamlComment` on a record component** comments that one key, at every nesting level:

```java
public record DatabaseConfig(
        @YamlComment("Host the database listens on") String host,
        @YamlComment("Port, usually 3306 for MySQL") int port) {}
```

```yaml
# Database settings
database:
  # Host the database listens on
  host: localhost
  # Port, usually 3306 for MySQL
  port: 3306
```

**`@YamlKey` on a record component** renames that one key, for writing and reading alike, so the file round-trips. A dotted key is rejected with an `IOException`: a component is one key inside the record's own block and cannot spread over a nested path.

**A bare `@YamlKey`** keys a field by its own field name. A field with no `@YamlKey` at all is still never persisted — the annotation is what marks a field as configuration; leaving its value blank only delegates the spelling of the key.

**`@YamlFile(naming = ...)`** decides how keys that must be *derived* from a Java identifier are spelled. Keys you spell out yourself are never touched.

| Strategy | `modelId` becomes |
|---|---|
| `SNAKE_CASE` (default) | `model_id` |
| `KEEP` | `modelId` |

Conversion is acronym-aware (`httpURL` -> `http_url`, `getHTTPHeader` -> `get_http_header`) and keeps a trailing digit attached to its word (`modelId2` -> `model_id2`).

## Compatibility

Both annotations are read off the component's **backing field**, which the compiler populates for any `FIELD`-targeted annotation written on a record component. Records compiled against earlier releases therefore work unchanged, with no `@Target` change and no recompile needed.

**The `SNAKE_CASE` default does change derived key spelling.** Record component keys and bare-`@YamlKey` field keys that were previously emitted verbatim are now converted, so `zipCode` becomes `zip_code`. Explicit `@YamlKey("...")` values — the overwhelming majority of existing configs — are unaffected. `@YamlFile(naming = Naming.KEEP)` restores the previous spelling exactly; a test pins that its output is byte-for-byte identical to before.

## Drive-by fix

The writer emitted record comments for list items. A list entry starts mid-line right after its `- `, so the comment landed there and pushed the following key to column 0:

```yaml
addresses:
  -     # Street name
street: 123 Main St        <- unparseable
```

Comments are now suppressed inside collections, where repeating the same block per item would be noise anyway.

## Tests

TDD throughout; every new behaviour had a failing test first. 264 tests pass across all four SnakeYAML versions CI builds (1.14, 1.33, 2.2, 2.4), with 100% line and branch coverage on every touched class.

- `RecordAnnotationTests` — comments per component, comments at both nesting levels, suppression inside collections, round trip, renames (save / load / hand-written YAML), rename authority over the component name, dotted-key rejection on save and load, and the `KEEP` byte-for-byte guarantee.
- `NamingTests` — the conversion table including `modelId2` and `httpURL`, `KEEP` as identity, both strategies end to end, explicit keys staying verbatim under **both** strategies, and round trips that would fail if only one side of reader/writer converted.
- `BareKeyTests` — derived key, round trip, and that an un-annotated field is still skipped.

Docs updated: `README.md`, `docs/annotations.md`, `docs/records.md`, `docs/examples.md`.