### PR TITLE
refactor: simplify record naming plumbing

### DIFF
--- a/src/main/java/org/avarion/yaml/Naming.java
+++ b/src/main/java/org/avarion/yaml/Naming.java
@@ -41,14 +41,6 @@ public enum Naming {
             return identifier;
         }
 
-        // Both patterns need an ASCII capital to fire, so an identifier already equal to its own
-        // lowercasing has no boundary to split on and is its own answer. Single-word names are the
-        // common case, and String#toLowerCase hands back the very same instance when no character
-        // changes, so this costs a reference comparison rather than two Matcher allocations.
-        if (identifier.toLowerCase(Locale.ENGLISH).equals(identifier)) {
-            return identifier;
-        }
-
         String separated = ACRONYM_BOUNDARY.matcher(identifier).replaceAll("$1_$2");
         separated = WORD_BOUNDARY.matcher(separated).replaceAll("$1_$2");
         return separated.toLowerCase(Locale.ENGLISH);

--- a/src/main/java/org/avarion/yaml/RecordComponents.java
+++ b/src/main/java/org/avarion/yaml/RecordComponents.java
@@ -4,17 +4,10 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
-import java.lang.annotation.Annotation;
 import java.lang.reflect.RecordComponent;
-import java.util.Arrays;
 
 /**
  * Reads the YAML annotations off a record component.
- *
- * <p>{@link YamlKey} and {@link YamlComment} target fields, and the compiler propagates an
- * annotation written on a record component onto that component's backing private final field.
- * Reading the field is therefore the one lookup that works for every record, no matter which
- * release of this library it was compiled against.</p>
  */
 final class RecordComponents {
 
@@ -30,7 +23,7 @@ final class RecordComponents {
      *                     component cannot spread itself over a nested path.
      */
     static @NotNull String keyOf(final @NotNull RecordComponent component, final @NotNull Naming naming) throws IOException {
-        YamlKey annotation = annotationOn(component, YamlKey.class);
+        YamlKey annotation = component.getAnnotation(YamlKey.class);
         String key = annotation == null ? "" : annotation.value().trim();
 
         if (key.isEmpty()) {
@@ -48,15 +41,7 @@ final class RecordComponents {
      * The {@link YamlComment} text for a component, or {@code null} when it has none.
      */
     static @Nullable String commentOf(final @NotNull RecordComponent component) {
-        YamlComment annotation = annotationOn(component, YamlComment.class);
+        YamlComment annotation = component.getAnnotation(YamlComment.class);
         return annotation == null ? null : annotation.value();
-    }
-
-    private static <A extends Annotation> @Nullable A annotationOn(final @NotNull RecordComponent component, final @NotNull Class<A> annotationType) {
-        return Arrays.stream(component.getDeclaringRecord().getDeclaredFields())
-                     .filter(field -> field.getName().equals(component.getName()))
-                     .findFirst()
-                     .map(field -> field.getAnnotation(annotationType))
-                     .orElse(null);
     }
 }

--- a/src/main/java/org/avarion/yaml/TypeConverter.java
+++ b/src/main/java/org/avarion/yaml/TypeConverter.java
@@ -1,5 +1,7 @@
 package org.avarion.yaml;
 
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -15,6 +17,7 @@ import java.util.logging.Logger;
  * Converts between YAML values (strings, numbers, maps, collections) and Java types.
  */
 @SuppressWarnings("unchecked")
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 final class TypeConverter {
 
     static final Logger LOG = Logger.getLogger(TypeConverter.class.getName());
@@ -55,26 +58,23 @@ final class TypeConverter {
         COLLECTION_FACTORIES.put(Queue.class, ArrayDeque::new);
     }
 
-    private TypeConverter() {
-        // Utility class
-    }
+    /** How keys derived from a record component's name are spelled. */
+    private final Naming naming;
 
     // ==================== Main Entry Points ====================
 
     /**
      * Convert a value to the type specified by the field.
      */
-    static @Nullable Object getConvertedValue(final @NotNull Field field, final Object value, boolean isLenient, final @NotNull Naming naming)
-            throws IOException {
-        return getConvertedValue(field, field.getType(), value, isLenient, naming);
+    @Nullable Object getConvertedValue(final @NotNull Field field, final Object value, boolean isLenient) throws IOException {
+        return getConvertedValue(field, field.getType(), value, isLenient);
     }
 
     /**
      * Convert a value to the expected type with optional field context.
      */
-    static @Nullable Object getConvertedValue(
-            final @Nullable Field field, final @NotNull Class<?> expectedType, final Object value, boolean isLenient, final @NotNull Naming naming)
-            throws IOException {
+    @Nullable Object getConvertedValue(
+            final @Nullable Field field, final @NotNull Class<?> expectedType, final Object value, boolean isLenient) throws IOException {
         if (value == null) {
             return handleNullValue(expectedType, field);
         }
@@ -90,15 +90,15 @@ final class TypeConverter {
         }
 
         if (value instanceof List<?>) {
-            return handleCollectionValue(field, expectedType, (Collection<?>) value, isLenient, naming);
+            return handleCollectionValue(field, expectedType, (Collection<?>) value, isLenient);
         }
         if (Collection.class.isAssignableFrom(expectedType) && isLenient) {
             // We allow a single String/int/... to be assigned to a Collection -- but only when we're in lenient mode
-            return handleCollectionValue(field, expectedType, List.of(value), isLenient, naming);
+            return handleCollectionValue(field, expectedType, List.of(value), isLenient);
         }
 
         if (value instanceof Map && Map.class.isAssignableFrom(expectedType)) {
-            return handleMapValue(field, expectedType, (Map<?, ?>) value, isLenient, naming);
+            return handleMapValue(field, expectedType, (Map<?, ?>) value, isLenient);
         }
 
         if (expectedType.isInstance(value)) {
@@ -123,7 +123,7 @@ final class TypeConverter {
 
         // Handle Records: convert Map to Record using canonical constructor
         if (value instanceof Map && expectedType.isRecord()) {
-            return convertMapToRecord(expectedType, (Map<?, ?>) value, isLenient, naming);
+            return convertMapToRecord(expectedType, (Map<?, ?>) value, isLenient);
         }
 
         // For other classes, attempt to use their constructor that takes a String parameter
@@ -146,8 +146,7 @@ final class TypeConverter {
      * This method handles parameterized types (Maps/Collections with generic info).
      * For simple types, it delegates to getConvertedValue to avoid code duplication.
      */
-    static @Nullable Object convertWithType(final @NotNull Type type, final Object value, boolean isLenient, final @NotNull Naming naming)
-            throws IOException {
+    @Nullable Object convertWithType(final @NotNull Type type, final Object value, boolean isLenient) throws IOException {
         Class<?> rawClass = getRawClass(type);
 
         if (value == null) {
@@ -168,8 +167,8 @@ final class TypeConverter {
             }
 
             for (Map.Entry<?, ?> entry : ((Map<?, ?>) value).entrySet()) {
-                Object convertedKey = convertWithType(keyType, entry.getKey(), isLenient, naming);
-                Object convertedValue = convertWithType(valueType, entry.getValue(), isLenient, naming);
+                Object convertedKey = convertWithType(keyType, entry.getKey(), isLenient);
+                Object convertedValue = convertWithType(valueType, entry.getValue(), isLenient);
                 if (convertedKey == LENIENT_ENUM_SKIP || convertedValue == LENIENT_ENUM_SKIP) {
                     continue;
                 }
@@ -190,7 +189,7 @@ final class TypeConverter {
             }
 
             for (Object item : (Collection<?>) value) {
-                Object convertedItem = convertWithType(elementType, item, isLenient, naming);
+                Object convertedItem = convertWithType(elementType, item, isLenient);
                 if (convertedItem == LENIENT_ENUM_SKIP) {
                     continue;
                 }
@@ -201,7 +200,7 @@ final class TypeConverter {
 
         // For all other types (primitives, String, enums, UUID, numbers, chars, etc.),
         // delegate to getConvertedValue which has all the conversion logic in one place.
-        return getConvertedValue(null, rawClass, value, isLenient, naming);
+        return getConvertedValue(null, rawClass, value, isLenient);
     }
 
     // ==================== Collection Handling ====================
@@ -209,9 +208,9 @@ final class TypeConverter {
     /**
      * Convert the incoming value into a Set/List/Queue.
      */
-    private static @NotNull Object handleCollectionValue(
-            final @Nullable Field field, final @NotNull Class<?> expectedType, final @NotNull Collection<?> collection, boolean isLenient,
-            final @NotNull Naming naming) throws IOException {
+    private @NotNull Object handleCollectionValue(
+            final @Nullable Field field, final @NotNull Class<?> expectedType, final @NotNull Collection<?> collection, boolean isLenient)
+            throws IOException {
 
         Collection<Object> result = createCollectionInstance(expectedType);
 
@@ -221,7 +220,7 @@ final class TypeConverter {
                 : Object.class;
 
         for (Object item : collection) {
-            Object convertedValue = convertWithType(elementType, item, isLenient, naming);
+            Object convertedValue = convertWithType(elementType, item, isLenient);
             if (convertedValue == LENIENT_ENUM_SKIP) {
                 continue;
             }
@@ -233,9 +232,8 @@ final class TypeConverter {
     /**
      * Convert the incoming value into a Map with properly typed keys and values.
      */
-    private static @NotNull Object handleMapValue(
-            final @NotNull Field field, final @NotNull Class<?> expectedType, final Map<?, ?> map, boolean isLenient, final @NotNull Naming naming)
-            throws IOException {
+    private @NotNull Object handleMapValue(
+            final @NotNull Field field, final @NotNull Class<?> expectedType, final Map<?, ?> map, boolean isLenient) throws IOException {
 
         Map<Object, Object> result = new LinkedHashMap<>();
 
@@ -249,8 +247,8 @@ final class TypeConverter {
         }
 
         for (Map.Entry<?, ?> entry : map.entrySet()) {
-            Object convertedKey = convertWithType(keyType, entry.getKey(), isLenient, naming);
-            Object convertedValue = convertWithType(valueType, entry.getValue(), isLenient, naming);
+            Object convertedKey = convertWithType(keyType, entry.getKey(), isLenient);
+            Object convertedValue = convertWithType(valueType, entry.getValue(), isLenient);
             if (convertedKey == LENIENT_ENUM_SKIP || convertedValue == LENIENT_ENUM_SKIP) {
                 continue;
             }
@@ -278,8 +276,7 @@ final class TypeConverter {
      * Supports nested records: if a component is itself a record and the value is a Map,
      * it will recursively convert the nested Map to the nested record type.
      */
-    private static @NotNull Object convertMapToRecord(
-            final @NotNull Class<?> recordClass, final @NotNull Map<?, ?> map, boolean isLenient, final @NotNull Naming naming) throws IOException {
+    private @NotNull Object convertMapToRecord(final @NotNull Class<?> recordClass, final @NotNull Map<?, ?> map, boolean isLenient) throws IOException {
         RecordComponent[] components = recordClass.getRecordComponents();
         Object[] args = new Object[components.length];
 
@@ -301,19 +298,19 @@ final class TypeConverter {
             }
             else if (value instanceof Map && componentType.isRecord()) {
                 // Nested record: recursively convert
-                args[i] = convertMapToRecord(componentType, (Map<?, ?>) value, isLenient, naming);
+                args[i] = convertMapToRecord(componentType, (Map<?, ?>) value, isLenient);
             }
             else if (value instanceof Map && Map.class.isAssignableFrom(componentType)) {
                 // Map field within record: use convertWithType for proper type handling
-                args[i] = convertWithType(genericType, value, isLenient, naming);
+                args[i] = convertWithType(genericType, value, isLenient);
             }
             else if (value instanceof Collection && Collection.class.isAssignableFrom(componentType)) {
                 // Collection field within record: use convertWithType for proper type handling
-                args[i] = convertWithType(genericType, value, isLenient, naming);
+                args[i] = convertWithType(genericType, value, isLenient);
             }
             else {
                 // Regular field: use getConvertedValue for type coercion
-                args[i] = getConvertedValue(null, componentType, value, isLenient, naming);
+                args[i] = getConvertedValue(null, componentType, value, isLenient);
             }
 
             // A record component cannot be skipped, so a lenient enum-skip becomes null

--- a/src/main/java/org/avarion/yaml/TypeConverter.java
+++ b/src/main/java/org/avarion/yaml/TypeConverter.java
@@ -61,20 +61,22 @@ final class TypeConverter {
     /** How keys derived from a record component's name are spelled. */
     private final Naming naming;
 
+    /** Whether a value that doesn't fit its target type is coerced with a warning, or rejected outright. */
+    private final boolean isLenient;
+
     // ==================== Main Entry Points ====================
 
     /**
      * Convert a value to the type specified by the field.
      */
-    @Nullable Object getConvertedValue(final @NotNull Field field, final Object value, boolean isLenient) throws IOException {
-        return getConvertedValue(field, field.getType(), value, isLenient);
+    @Nullable Object getConvertedValue(final @NotNull Field field, final Object value) throws IOException {
+        return getConvertedValue(field, field.getType(), value);
     }
 
     /**
      * Convert a value to the expected type with optional field context.
      */
-    @Nullable Object getConvertedValue(
-            final @Nullable Field field, final @NotNull Class<?> expectedType, final Object value, boolean isLenient) throws IOException {
+    @Nullable Object getConvertedValue(final @Nullable Field field, final @NotNull Class<?> expectedType, final Object value) throws IOException {
         if (value == null) {
             return handleNullValue(expectedType, field);
         }
@@ -86,19 +88,19 @@ final class TypeConverter {
         }
 
         if (expectedType.isEnum() && value instanceof String convertedValue) {
-            return stringToEnum((Class<? extends Enum>) expectedType, convertedValue, isLenient);
+            return stringToEnum((Class<? extends Enum>) expectedType, convertedValue);
         }
 
         if (value instanceof List<?>) {
-            return handleCollectionValue(field, expectedType, (Collection<?>) value, isLenient);
+            return handleCollectionValue(field, expectedType, (Collection<?>) value);
         }
         if (Collection.class.isAssignableFrom(expectedType) && isLenient) {
             // We allow a single String/int/... to be assigned to a Collection -- but only when we're in lenient mode
-            return handleCollectionValue(field, expectedType, List.of(value), isLenient);
+            return handleCollectionValue(field, expectedType, List.of(value));
         }
 
         if (value instanceof Map && Map.class.isAssignableFrom(expectedType)) {
-            return handleMapValue(field, expectedType, (Map<?, ?>) value, isLenient);
+            return handleMapValue(field, expectedType, (Map<?, ?>) value);
         }
 
         if (expectedType.isInstance(value)) {
@@ -114,16 +116,16 @@ final class TypeConverter {
         }
 
         if (Number.class.isAssignableFrom(value.getClass())) {
-            return convertToNumber((Number) value, expectedType, isLenient);
+            return convertToNumber((Number) value, expectedType);
         }
 
         if (isCharacterType(expectedType)) {
-            return convertToCharacter(String.valueOf(value), isLenient);
+            return convertToCharacter(String.valueOf(value));
         }
 
         // Handle Records: convert Map to Record using canonical constructor
         if (value instanceof Map && expectedType.isRecord()) {
-            return convertMapToRecord(expectedType, (Map<?, ?>) value, isLenient);
+            return convertMapToRecord(expectedType, (Map<?, ?>) value);
         }
 
         // For other classes, attempt to use their constructor that takes a String parameter
@@ -146,7 +148,7 @@ final class TypeConverter {
      * This method handles parameterized types (Maps/Collections with generic info).
      * For simple types, it delegates to getConvertedValue to avoid code duplication.
      */
-    @Nullable Object convertWithType(final @NotNull Type type, final Object value, boolean isLenient) throws IOException {
+    @Nullable Object convertWithType(final @NotNull Type type, final Object value) throws IOException {
         Class<?> rawClass = getRawClass(type);
 
         if (value == null) {
@@ -167,8 +169,8 @@ final class TypeConverter {
             }
 
             for (Map.Entry<?, ?> entry : ((Map<?, ?>) value).entrySet()) {
-                Object convertedKey = convertWithType(keyType, entry.getKey(), isLenient);
-                Object convertedValue = convertWithType(valueType, entry.getValue(), isLenient);
+                Object convertedKey = convertWithType(keyType, entry.getKey());
+                Object convertedValue = convertWithType(valueType, entry.getValue());
                 if (convertedKey == LENIENT_ENUM_SKIP || convertedValue == LENIENT_ENUM_SKIP) {
                     continue;
                 }
@@ -189,7 +191,7 @@ final class TypeConverter {
             }
 
             for (Object item : (Collection<?>) value) {
-                Object convertedItem = convertWithType(elementType, item, isLenient);
+                Object convertedItem = convertWithType(elementType, item);
                 if (convertedItem == LENIENT_ENUM_SKIP) {
                     continue;
                 }
@@ -200,7 +202,7 @@ final class TypeConverter {
 
         // For all other types (primitives, String, enums, UUID, numbers, chars, etc.),
         // delegate to getConvertedValue which has all the conversion logic in one place.
-        return getConvertedValue(null, rawClass, value, isLenient);
+        return getConvertedValue(null, rawClass, value);
     }
 
     // ==================== Collection Handling ====================
@@ -209,8 +211,7 @@ final class TypeConverter {
      * Convert the incoming value into a Set/List/Queue.
      */
     private @NotNull Object handleCollectionValue(
-            final @Nullable Field field, final @NotNull Class<?> expectedType, final @NotNull Collection<?> collection, boolean isLenient)
-            throws IOException {
+            final @Nullable Field field, final @NotNull Class<?> expectedType, final @NotNull Collection<?> collection) throws IOException {
 
         Collection<Object> result = createCollectionInstance(expectedType);
 
@@ -220,7 +221,7 @@ final class TypeConverter {
                 : Object.class;
 
         for (Object item : collection) {
-            Object convertedValue = convertWithType(elementType, item, isLenient);
+            Object convertedValue = convertWithType(elementType, item);
             if (convertedValue == LENIENT_ENUM_SKIP) {
                 continue;
             }
@@ -232,8 +233,7 @@ final class TypeConverter {
     /**
      * Convert the incoming value into a Map with properly typed keys and values.
      */
-    private @NotNull Object handleMapValue(
-            final @NotNull Field field, final @NotNull Class<?> expectedType, final Map<?, ?> map, boolean isLenient) throws IOException {
+    private @NotNull Object handleMapValue(final @NotNull Field field, final @NotNull Class<?> expectedType, final Map<?, ?> map) throws IOException {
 
         Map<Object, Object> result = new LinkedHashMap<>();
 
@@ -247,8 +247,8 @@ final class TypeConverter {
         }
 
         for (Map.Entry<?, ?> entry : map.entrySet()) {
-            Object convertedKey = convertWithType(keyType, entry.getKey(), isLenient);
-            Object convertedValue = convertWithType(valueType, entry.getValue(), isLenient);
+            Object convertedKey = convertWithType(keyType, entry.getKey());
+            Object convertedValue = convertWithType(valueType, entry.getValue());
             if (convertedKey == LENIENT_ENUM_SKIP || convertedValue == LENIENT_ENUM_SKIP) {
                 continue;
             }
@@ -276,7 +276,7 @@ final class TypeConverter {
      * Supports nested records: if a component is itself a record and the value is a Map,
      * it will recursively convert the nested Map to the nested record type.
      */
-    private @NotNull Object convertMapToRecord(final @NotNull Class<?> recordClass, final @NotNull Map<?, ?> map, boolean isLenient) throws IOException {
+    private @NotNull Object convertMapToRecord(final @NotNull Class<?> recordClass, final @NotNull Map<?, ?> map) throws IOException {
         RecordComponent[] components = recordClass.getRecordComponents();
         Object[] args = new Object[components.length];
 
@@ -298,19 +298,19 @@ final class TypeConverter {
             }
             else if (value instanceof Map && componentType.isRecord()) {
                 // Nested record: recursively convert
-                args[i] = convertMapToRecord(componentType, (Map<?, ?>) value, isLenient);
+                args[i] = convertMapToRecord(componentType, (Map<?, ?>) value);
             }
             else if (value instanceof Map && Map.class.isAssignableFrom(componentType)) {
                 // Map field within record: use convertWithType for proper type handling
-                args[i] = convertWithType(genericType, value, isLenient);
+                args[i] = convertWithType(genericType, value);
             }
             else if (value instanceof Collection && Collection.class.isAssignableFrom(componentType)) {
                 // Collection field within record: use convertWithType for proper type handling
-                args[i] = convertWithType(genericType, value, isLenient);
+                args[i] = convertWithType(genericType, value);
             }
             else {
                 // Regular field: use getConvertedValue for type coercion
-                args[i] = getConvertedValue(null, componentType, value, isLenient);
+                args[i] = getConvertedValue(null, componentType, value);
             }
 
             // A record component cannot be skipped, so a lenient enum-skip becomes null
@@ -359,7 +359,7 @@ final class TypeConverter {
         return TRUE_VALUES.contains(strValue);
     }
 
-    private static Object convertToNumber(final Number numValue, final Class<?> expectedType, boolean isLenient) throws IOException {
+    private Object convertToNumber(final Number numValue, final Class<?> expectedType) throws IOException {
         if (expectedType == int.class || expectedType == Integer.class) {
             return numValue.intValue();
         }
@@ -367,7 +367,7 @@ final class TypeConverter {
             return numValue.doubleValue();
         }
         if (expectedType == float.class || expectedType == Float.class) {
-            return convertToFloat(numValue, isLenient);
+            return convertToFloat(numValue);
         }
         if (expectedType == long.class || expectedType == Long.class) {
             return numValue.longValue();
@@ -381,7 +381,7 @@ final class TypeConverter {
         throw new IOException("Cannot convert " + numValue.getClass().getSimpleName() + " to " + expectedType.getSimpleName());
     }
 
-    private static float convertToFloat(final @NotNull Number numValue, boolean isLenient) throws IOException {
+    private float convertToFloat(final @NotNull Number numValue) throws IOException {
         double doubleValue = numValue.doubleValue();
         boolean lossy = Math.abs(doubleValue - (float) doubleValue) >= 1e-9;
         if (lossy) {
@@ -397,7 +397,7 @@ final class TypeConverter {
         return type == char.class || type == Character.class;
     }
 
-    private static @NotNull Character convertToCharacter(final @NotNull String value, boolean isLenient) throws IOException {
+    private @NotNull Character convertToCharacter(final @NotNull String value) throws IOException {
         if (value.length() == 1) {
             return value.charAt(0);
         }
@@ -413,7 +413,7 @@ final class TypeConverter {
      * {@link #LENIENT_ENUM_SKIP} instead of throwing; iterators in collection/map paths
      * use that sentinel to drop the offending entry.
      */
-    private static @NotNull Object stringToEnum(final Class<? extends Enum> enumClass, final @NotNull String value, boolean isLenient) {
+    private @NotNull Object stringToEnum(final Class<? extends Enum> enumClass, final @NotNull String value) {
         try {
             return Enum.valueOf(enumClass, value.toUpperCase());
         } catch (IllegalArgumentException ex) {

--- a/src/main/java/org/avarion/yaml/YamlComment.java
+++ b/src/main/java/org/avarion/yaml/YamlComment.java
@@ -27,7 +27,7 @@ import java.lang.annotation.Target;
  * }</pre>
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.FIELD})
+@Target({ElementType.FIELD, ElementType.RECORD_COMPONENT})
 public @interface YamlComment {
 	@NotNull String value() default "";
 }

--- a/src/main/java/org/avarion/yaml/YamlFileInterface.java
+++ b/src/main/java/org/avarion/yaml/YamlFileInterface.java
@@ -247,7 +247,7 @@ public abstract class YamlFileInterface {
 
         Object value = getNestedValue(data, key.split("\\."));
         if (value != UNKNOWN) {
-            Object converted = new TypeConverter(naming).getConvertedValue(field, value, isLenient);
+            Object converted = new TypeConverter(naming, isLenient).getConvertedValue(field, value);
             if (converted == TypeConverter.LENIENT_ENUM_SKIP) {
                 // Lenient mode: bad enum value at top level — leave field at its default
                 return;

--- a/src/main/java/org/avarion/yaml/YamlFileInterface.java
+++ b/src/main/java/org/avarion/yaml/YamlFileInterface.java
@@ -247,7 +247,7 @@ public abstract class YamlFileInterface {
 
         Object value = getNestedValue(data, key.split("\\."));
         if (value != UNKNOWN) {
-            Object converted = TypeConverter.getConvertedValue(field, value, isLenient, naming);
+            Object converted = new TypeConverter(naming).getConvertedValue(field, value, isLenient);
             if (converted == TypeConverter.LENIENT_ENUM_SKIP) {
                 // Lenient mode: bad enum value at top level — leave field at its default
                 return;

--- a/src/main/java/org/avarion/yaml/YamlKey.java
+++ b/src/main/java/org/avarion/yaml/YamlKey.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
  * }</pre>
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.FIELD})
+@Target({ElementType.FIELD, ElementType.RECORD_COMPONENT})
 public @interface YamlKey {
 	String value() default "";
     Leniency lenient() default Leniency.UNDEFINED;

--- a/src/test/java/org/avarion/yaml/NamingTests.java
+++ b/src/test/java/org/avarion/yaml/NamingTests.java
@@ -73,26 +73,6 @@ class NamingTests extends TestCommon {
                 """, readFile());
     }
 
-    // ===== An explicit key is never converted, under either strategy =====
-
-    @Test
-    void testExplicitKeysStayVerbatimUnderSnakeCase() throws IOException {
-        new SnakeCaseNamingClass().save(target);
-
-        String yaml = readFile();
-        assertEquals(true, yaml.contains("  someCamelKey: e\n"), yaml);
-        assertEquals(true, yaml.contains("anExplicitFieldKey: kept\n"), yaml);
-    }
-
-    @Test
-    void testExplicitKeysStayVerbatimUnderKeep() throws IOException {
-        new KeepNamingClass().save(target);
-
-        String yaml = readFile();
-        assertEquals(true, yaml.contains("  someCamelKey: e\n"), yaml);
-        assertEquals(true, yaml.contains("anExplicitFieldKey: kept\n"), yaml);
-    }
-
     // ===== Reader and writer agree =====
 
     @Test

--- a/src/test/java/org/avarion/yaml/TypeConverterDirectTest.java
+++ b/src/test/java/org/avarion/yaml/TypeConverterDirectTest.java
@@ -17,40 +17,43 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class TypeConverterDirectTest {
 
+    /** Stateless apart from its naming strategy, so one instance serves every test. */
+    private static final TypeConverter converter = new TypeConverter(Naming.SNAKE_CASE);
+
     // ==================== getConvertedValue tests ====================
 
     @Test
     void testObjectTypeWithMapValueReturnsAsIs() throws IOException {
         Map<String, Object> mapValue = Map.of("key", "value");
-        Object result = TypeConverter.getConvertedValue(null, Object.class, mapValue, false, Naming.SNAKE_CASE);
+        Object result = converter.getConvertedValue(null, Object.class, mapValue, false);
         assertSame(mapValue, result);
     }
 
     @Test
     void testObjectTypeWithCollectionValueReturnsAsIs() throws IOException {
         List<String> listValue = List.of("a", "b");
-        Object result = TypeConverter.getConvertedValue(null, Object.class, listValue, false, Naming.SNAKE_CASE);
+        Object result = converter.getConvertedValue(null, Object.class, listValue, false);
         assertSame(listValue, result);
     }
 
     @Test
     void testObjectTypeWithScalarValueDoesNotReturnAsIs() throws IOException {
         // Object.class + non-collection/non-map → should fall through to isInstance check
-        Object result = TypeConverter.getConvertedValue(null, Object.class, "hello", false, Naming.SNAKE_CASE);
+        Object result = converter.getConvertedValue(null, Object.class, "hello", false);
         assertEquals("hello", result);
     }
 
     @Test
     void testNullValueForPrimitiveWithoutFieldThrowsWithoutFieldName() {
         IOException thrown = assertThrows(IOException.class, () ->
-                TypeConverter.getConvertedValue(null, int.class, null, false, Naming.SNAKE_CASE));
+                converter.getConvertedValue(null, int.class, null, false));
         assertEquals("Cannot assign null to primitive type int", thrown.getMessage());
         assertFalse(thrown.getMessage().contains("field:"));
     }
 
     @Test
     void testNullValueForNonPrimitiveReturnsNull() throws IOException {
-        Object result = TypeConverter.getConvertedValue(null, String.class, null, false, Naming.SNAKE_CASE);
+        Object result = converter.getConvertedValue(null, String.class, null, false);
         assertNull(result);
     }
 
@@ -58,7 +61,7 @@ class TypeConverterDirectTest {
     void testEnumTypeWithNonStringValueFallsThrough() {
         // Enum type but value is Integer → should fall through enum check, hit Number check, then throw
         IOException thrown = assertThrows(IOException.class, () ->
-                TypeConverter.getConvertedValue(null, Material.class, 42, false, Naming.SNAKE_CASE));
+                converter.getConvertedValue(null, Material.class, 42, false));
         assertTrue(thrown.getMessage().contains("Cannot convert Integer to Material"));
     }
 
@@ -67,7 +70,7 @@ class TypeConverterDirectTest {
         // value is Map but expectedType is not Map and not Record → falls through to constructor/field attempts
         Map<String, Object> mapValue = Map.of("key", "value");
         IOException thrown = assertThrows(IOException.class, () ->
-                TypeConverter.getConvertedValue(null, Integer.class, mapValue, false, Naming.SNAKE_CASE));
+                converter.getConvertedValue(null, Integer.class, mapValue, false));
         assertTrue(thrown.getMessage().contains("I cannot figure out how to retrieve this type"));
     }
 
@@ -75,7 +78,7 @@ class TypeConverterDirectTest {
     void testStringValueWithNonUuidExpectedType() throws IOException {
         // String value with non-UUID expectedType → should not enter UUID branch
         // String for a String field → isInstance returns true
-        Object result = TypeConverter.getConvertedValue(null, String.class, "hello", false, Naming.SNAKE_CASE);
+        Object result = converter.getConvertedValue(null, String.class, "hello", false);
         assertEquals("hello", result);
     }
 
@@ -83,20 +86,20 @@ class TypeConverterDirectTest {
     void testNonStringValueWithUuidExpectedType() {
         // Non-string value for UUID type → skip UUID branch, skip boolean, hit Number, throw
         IOException thrown = assertThrows(IOException.class, () ->
-                TypeConverter.getConvertedValue(null, UUID.class, 42, false, Naming.SNAKE_CASE));
+                converter.getConvertedValue(null, UUID.class, 42, false));
         assertTrue(thrown.getMessage().contains("Cannot convert"));
     }
 
     @Test
     void testBooleanConversionFromBooleanObject() throws IOException {
         // Direct Boolean value → convertToBoolean returns as-is
-        Object result = TypeConverter.getConvertedValue(null, Boolean.class, Boolean.TRUE, false, Naming.SNAKE_CASE);
+        Object result = converter.getConvertedValue(null, Boolean.class, Boolean.TRUE, false);
         assertEquals(Boolean.TRUE, result);
     }
 
     @Test
     void testBooleanConversionFromStringNo() throws IOException {
-        Object result = TypeConverter.getConvertedValue(null, boolean.class, "no", false, Naming.SNAKE_CASE);
+        Object result = converter.getConvertedValue(null, boolean.class, "no", false);
         assertEquals(Boolean.FALSE, result);
     }
 
@@ -104,14 +107,14 @@ class TypeConverterDirectTest {
     void testCollectionWithLenientFalseDoesNotConvertSingleValue() {
         // Single String value, Collection expectedType, but NOT lenient → should fall through
         IOException thrown = assertThrows(IOException.class, () ->
-                TypeConverter.getConvertedValue(null, List.class, "single", false, Naming.SNAKE_CASE));
+                converter.getConvertedValue(null, List.class, "single", false));
         assertTrue(thrown.getMessage().contains("I cannot figure out how to retrieve this type"));
     }
 
     @Test
     void testCollectionWithLenientTrueConvertsSingleValue() throws IOException {
         // Single String value, Collection expectedType, lenient → wraps in List
-        Object result = TypeConverter.getConvertedValue(null, List.class, "single", true, Naming.SNAKE_CASE);
+        Object result = converter.getConvertedValue(null, List.class, "single", true);
         assertInstanceOf(List.class, result);
         assertEquals(List.of("single"), result);
     }
@@ -121,13 +124,13 @@ class TypeConverterDirectTest {
     @Test
     void testConvertWithTypeNullForPrimitiveThrows() {
         IOException thrown = assertThrows(IOException.class, () ->
-                TypeConverter.convertWithType(int.class, null, false, Naming.SNAKE_CASE));
+                converter.convertWithType(int.class, null, false));
         assertEquals("Cannot assign null to primitive type int", thrown.getMessage());
     }
 
     @Test
     void testConvertWithTypeNullForNonPrimitiveReturnsNull() throws IOException {
-        Object result = TypeConverter.convertWithType(String.class, null, false, Naming.SNAKE_CASE);
+        Object result = converter.convertWithType(String.class, null, false);
         assertNull(result);
     }
 
@@ -136,7 +139,7 @@ class TypeConverterDirectTest {
         // Map value with raw Map.class type (no parameterized type info)
         Map<String, Object> mapValue = new LinkedHashMap<>();
         mapValue.put("key", "value");
-        Object result = TypeConverter.convertWithType(Map.class, mapValue, false, Naming.SNAKE_CASE);
+        Object result = converter.convertWithType(Map.class, mapValue, false);
         assertInstanceOf(Map.class, result);
     }
 
@@ -144,13 +147,13 @@ class TypeConverterDirectTest {
     void testConvertWithTypeCollectionWithRawClass() throws IOException {
         // Collection value with raw List.class type (no parameterized type info)
         List<String> listValue = List.of("a", "b");
-        Object result = TypeConverter.convertWithType(List.class, listValue, false, Naming.SNAKE_CASE);
+        Object result = converter.convertWithType(List.class, listValue, false);
         assertInstanceOf(List.class, result);
     }
 
     @Test
     void testConvertWithTypeScalar() throws IOException {
-        Object result = TypeConverter.convertWithType(String.class, "hello", false, Naming.SNAKE_CASE);
+        Object result = converter.convertWithType(String.class, "hello", false);
         assertEquals("hello", result);
     }
 
@@ -166,7 +169,7 @@ class TypeConverterDirectTest {
     void testHandleCollectionValueWithRawListField() throws Exception {
         // Raw List field (no parameterized type) — element type falls through to Object.
         java.lang.reflect.Field rawList = RawFieldFixture.class.getField("rawList");
-        Object result = TypeConverter.getConvertedValue(rawList, List.class, List.of("a", "b"), false, Naming.SNAKE_CASE);
+        Object result = converter.getConvertedValue(rawList, List.class, List.of("a", "b"), false);
         assertEquals(List.of("a", "b"), result);
     }
 
@@ -176,7 +179,7 @@ class TypeConverterDirectTest {
         java.lang.reflect.Field rawMap = RawFieldFixture.class.getField("rawMap");
         Map<String, String> input = new LinkedHashMap<>();
         input.put("k", "v");
-        Object result = TypeConverter.getConvertedValue(rawMap, Map.class, input, false, Naming.SNAKE_CASE);
+        Object result = converter.getConvertedValue(rawMap, Map.class, input, false);
         assertEquals(input, result);
     }
 
@@ -286,7 +289,7 @@ class TypeConverterDirectTest {
         recordMap.put("zip_code", null); // int cannot be null
 
         IOException thrown = assertThrows(IOException.class, () ->
-                TypeConverter.getConvertedValue(null, Address.class, recordMap, false, Naming.SNAKE_CASE));
+                converter.getConvertedValue(null, Address.class, recordMap, false));
         assertTrue(thrown.getMessage().contains("Cannot assign null to primitive record component 'zipCode'"));
     }
 
@@ -303,7 +306,7 @@ class TypeConverterDirectTest {
         recordMap.put("name", "Student");
         recordMap.put("scores", innerMap);
 
-        Object result = TypeConverter.getConvertedValue(null, RecordWithMap.class, recordMap, false, Naming.SNAKE_CASE);
+        Object result = converter.getConvertedValue(null, RecordWithMap.class, recordMap, false);
         assertInstanceOf(RecordWithMap.class, result);
         RecordWithMap converted = (RecordWithMap) result;
         assertEquals("Student", converted.name());
@@ -319,7 +322,7 @@ class TypeConverterDirectTest {
         recordMap.put("name", "Item");
         recordMap.put("tags", tags);
 
-        Object result = TypeConverter.getConvertedValue(null, RecordWithList.class, recordMap, false, Naming.SNAKE_CASE);
+        Object result = converter.getConvertedValue(null, RecordWithList.class, recordMap, false);
         assertInstanceOf(RecordWithList.class, result);
         RecordWithList converted = (RecordWithList) result;
         assertEquals("Item", converted.name());
@@ -332,34 +335,34 @@ class TypeConverterDirectTest {
     void testNumberToUnsupportedTypeThrows() {
         // Number value but expectedType is not a numeric type
         IOException thrown = assertThrows(IOException.class, () ->
-                TypeConverter.getConvertedValue(null, UUID.class, 42, false, Naming.SNAKE_CASE));
+                converter.getConvertedValue(null, UUID.class, 42, false));
         assertTrue(thrown.getMessage().contains("Cannot convert Integer to UUID"));
     }
 
     @Test
     void testFloatConversionLenientAllowsPrecisionLoss() throws IOException {
         // Double that can't be exactly represented as float, but lenient mode allows it
-        Object result = TypeConverter.getConvertedValue(null, float.class, 1.234567890123, true, Naming.SNAKE_CASE);
+        Object result = converter.getConvertedValue(null, float.class, 1.234567890123, true);
         assertInstanceOf(Float.class, result);
     }
 
     @Test
     void testFloatConversionStrictRejectsPrecisionLoss() {
         IOException thrown = assertThrows(IOException.class, () ->
-                TypeConverter.getConvertedValue(null, float.class, 1.234567890123, false, Naming.SNAKE_CASE));
+                converter.getConvertedValue(null, float.class, 1.234567890123, false));
         assertTrue(thrown.getMessage().contains("cannot be precisely represented as a float"));
     }
 
     @Test
     void testCharacterConversionLenientTakesFirstChar() throws IOException {
-        Object result = TypeConverter.getConvertedValue(null, char.class, "abc", true, Naming.SNAKE_CASE);
+        Object result = converter.getConvertedValue(null, char.class, "abc", true);
         assertEquals('a', result);
     }
 
     @Test
     void testCharacterConversionStrictRejectsMultiChar() {
         IOException thrown = assertThrows(IOException.class, () ->
-                TypeConverter.getConvertedValue(null, char.class, "abc", false, Naming.SNAKE_CASE));
+                converter.getConvertedValue(null, char.class, "abc", false));
         assertTrue(thrown.getMessage().contains("Cannot convert String of length 3 to Character"));
     }
 
@@ -368,37 +371,37 @@ class TypeConverterDirectTest {
     @Test
     void testDoubleToIntegerConversion() throws IOException {
         // Double value being converted to Integer.class → hits the Integer.class branch in convertToNumber
-        Object result = TypeConverter.getConvertedValue(null, Integer.class, 42.0, false, Naming.SNAKE_CASE);
+        Object result = converter.getConvertedValue(null, Integer.class, 42.0, false);
         assertEquals(42, result);
     }
 
     @Test
     void testDoubleToLongConversion() throws IOException {
-        Object result = TypeConverter.getConvertedValue(null, Long.class, 42.0, false, Naming.SNAKE_CASE);
+        Object result = converter.getConvertedValue(null, Long.class, 42.0, false);
         assertEquals(42L, result);
     }
 
     @Test
     void testDoubleToShortConversion() throws IOException {
-        Object result = TypeConverter.getConvertedValue(null, Short.class, 42.0, false, Naming.SNAKE_CASE);
+        Object result = converter.getConvertedValue(null, Short.class, 42.0, false);
         assertEquals((short) 42, result);
     }
 
     @Test
     void testDoubleToByteConversion() throws IOException {
-        Object result = TypeConverter.getConvertedValue(null, Byte.class, 42.0, false, Naming.SNAKE_CASE);
+        Object result = converter.getConvertedValue(null, Byte.class, 42.0, false);
         assertEquals((byte) 42, result);
     }
 
     @Test
     void testIntToDoubleConversion() throws IOException {
-        Object result = TypeConverter.getConvertedValue(null, Double.class, 42, false, Naming.SNAKE_CASE);
+        Object result = converter.getConvertedValue(null, Double.class, 42, false);
         assertEquals(42.0, result);
     }
 
     @Test
     void testIntToFloatConversion() throws IOException {
-        Object result = TypeConverter.getConvertedValue(null, Float.class, 42, false, Naming.SNAKE_CASE);
+        Object result = converter.getConvertedValue(null, Float.class, 42, false);
         assertEquals(42.0f, result);
     }
 
@@ -428,7 +431,7 @@ class TypeConverterDirectTest {
         mapValue.put("key1", 10);
         mapValue.put("key2", 20);
 
-        Object result = TypeConverter.convertWithType(mapType, mapValue, false, Naming.SNAKE_CASE);
+        Object result = converter.convertWithType(mapType, mapValue, false);
         assertInstanceOf(Map.class, result);
         Map<?, ?> resultMap = (Map<?, ?>) result;
         assertEquals(10, resultMap.get("key1"));
@@ -455,7 +458,7 @@ class TypeConverterDirectTest {
         };
 
         List<String> listValue = List.of("a", "b");
-        Object result = TypeConverter.convertWithType(listType, listValue, false, Naming.SNAKE_CASE);
+        Object result = converter.convertWithType(listType, listValue, false);
         assertInstanceOf(List.class, result);
         assertEquals(2, ((List<?>) result).size());
     }
@@ -485,7 +488,7 @@ class TypeConverterDirectTest {
         Map<String, Object> mapValue = new LinkedHashMap<>();
         mapValue.put("key", "value");
 
-        Object result = TypeConverter.convertWithType(rawMapType, mapValue, false, Naming.SNAKE_CASE);
+        Object result = converter.convertWithType(rawMapType, mapValue, false);
         assertInstanceOf(Map.class, result);
     }
 
@@ -509,7 +512,7 @@ class TypeConverterDirectTest {
         };
 
         List<String> listValue = List.of("a", "b");
-        Object result = TypeConverter.convertWithType(rawListType, listValue, false, Naming.SNAKE_CASE);
+        Object result = converter.convertWithType(rawListType, listValue, false);
         assertInstanceOf(List.class, result);
     }
 
@@ -536,7 +539,7 @@ class TypeConverterDirectTest {
         Map<String, Object> mapValue = new LinkedHashMap<>();
         mapValue.put("key", "value");
 
-        Object result = TypeConverter.convertWithType(singleArgMapType, mapValue, false, Naming.SNAKE_CASE);
+        Object result = converter.convertWithType(singleArgMapType, mapValue, false);
         assertInstanceOf(Map.class, result);
     }
 
@@ -550,7 +553,7 @@ class TypeConverterDirectTest {
         recordMap.put("value", -1);
 
         IOException thrown = assertThrows(IOException.class, () ->
-                TypeConverter.getConvertedValue(null, ValidatingRecord.class, recordMap, false, Naming.SNAKE_CASE));
+                converter.getConvertedValue(null, ValidatingRecord.class, recordMap, false));
         assertTrue(thrown.getMessage().contains("Failed to instantiate record ValidatingRecord"));
     }
 
@@ -566,7 +569,7 @@ class TypeConverterDirectTest {
         recordMap.put("zip_code", 12345);
 
         // String has a String(String) constructor, so Map.toString() will be used
-        Object result = TypeConverter.getConvertedValue(null, Address.class, recordMap, false, Naming.SNAKE_CASE);
+        Object result = converter.getConvertedValue(null, Address.class, recordMap, false);
         assertInstanceOf(Address.class, result);
         // The map's toString becomes the street value
         Address addr = (Address) result;
@@ -586,6 +589,6 @@ class TypeConverterDirectTest {
 
         // Falls through to else block, then getConvertedValue tries to create String collection → fails
         assertThrows(IOException.class, () ->
-                TypeConverter.getConvertedValue(null, Address.class, recordMap, false, Naming.SNAKE_CASE));
+                converter.getConvertedValue(null, Address.class, recordMap, false));
     }
 }

--- a/src/test/java/org/avarion/yaml/TypeConverterDirectTest.java
+++ b/src/test/java/org/avarion/yaml/TypeConverterDirectTest.java
@@ -17,43 +17,44 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class TypeConverterDirectTest {
 
-    /** Stateless apart from its naming strategy, so one instance serves every test. */
-    private static final TypeConverter converter = new TypeConverter(Naming.SNAKE_CASE);
+    /** Stateless apart from naming and leniency, so one instance per mode serves every test. */
+    private static final TypeConverter strict = new TypeConverter(Naming.SNAKE_CASE, false);
+    private static final TypeConverter lenient = new TypeConverter(Naming.SNAKE_CASE, true);
 
     // ==================== getConvertedValue tests ====================
 
     @Test
     void testObjectTypeWithMapValueReturnsAsIs() throws IOException {
         Map<String, Object> mapValue = Map.of("key", "value");
-        Object result = converter.getConvertedValue(null, Object.class, mapValue, false);
+        Object result = strict.getConvertedValue(null, Object.class, mapValue);
         assertSame(mapValue, result);
     }
 
     @Test
     void testObjectTypeWithCollectionValueReturnsAsIs() throws IOException {
         List<String> listValue = List.of("a", "b");
-        Object result = converter.getConvertedValue(null, Object.class, listValue, false);
+        Object result = strict.getConvertedValue(null, Object.class, listValue);
         assertSame(listValue, result);
     }
 
     @Test
     void testObjectTypeWithScalarValueDoesNotReturnAsIs() throws IOException {
         // Object.class + non-collection/non-map → should fall through to isInstance check
-        Object result = converter.getConvertedValue(null, Object.class, "hello", false);
+        Object result = strict.getConvertedValue(null, Object.class, "hello");
         assertEquals("hello", result);
     }
 
     @Test
     void testNullValueForPrimitiveWithoutFieldThrowsWithoutFieldName() {
         IOException thrown = assertThrows(IOException.class, () ->
-                converter.getConvertedValue(null, int.class, null, false));
+                strict.getConvertedValue(null, int.class, null));
         assertEquals("Cannot assign null to primitive type int", thrown.getMessage());
         assertFalse(thrown.getMessage().contains("field:"));
     }
 
     @Test
     void testNullValueForNonPrimitiveReturnsNull() throws IOException {
-        Object result = converter.getConvertedValue(null, String.class, null, false);
+        Object result = strict.getConvertedValue(null, String.class, null);
         assertNull(result);
     }
 
@@ -61,7 +62,7 @@ class TypeConverterDirectTest {
     void testEnumTypeWithNonStringValueFallsThrough() {
         // Enum type but value is Integer → should fall through enum check, hit Number check, then throw
         IOException thrown = assertThrows(IOException.class, () ->
-                converter.getConvertedValue(null, Material.class, 42, false));
+                strict.getConvertedValue(null, Material.class, 42));
         assertTrue(thrown.getMessage().contains("Cannot convert Integer to Material"));
     }
 
@@ -70,7 +71,7 @@ class TypeConverterDirectTest {
         // value is Map but expectedType is not Map and not Record → falls through to constructor/field attempts
         Map<String, Object> mapValue = Map.of("key", "value");
         IOException thrown = assertThrows(IOException.class, () ->
-                converter.getConvertedValue(null, Integer.class, mapValue, false));
+                strict.getConvertedValue(null, Integer.class, mapValue));
         assertTrue(thrown.getMessage().contains("I cannot figure out how to retrieve this type"));
     }
 
@@ -78,7 +79,7 @@ class TypeConverterDirectTest {
     void testStringValueWithNonUuidExpectedType() throws IOException {
         // String value with non-UUID expectedType → should not enter UUID branch
         // String for a String field → isInstance returns true
-        Object result = converter.getConvertedValue(null, String.class, "hello", false);
+        Object result = strict.getConvertedValue(null, String.class, "hello");
         assertEquals("hello", result);
     }
 
@@ -86,20 +87,20 @@ class TypeConverterDirectTest {
     void testNonStringValueWithUuidExpectedType() {
         // Non-string value for UUID type → skip UUID branch, skip boolean, hit Number, throw
         IOException thrown = assertThrows(IOException.class, () ->
-                converter.getConvertedValue(null, UUID.class, 42, false));
+                strict.getConvertedValue(null, UUID.class, 42));
         assertTrue(thrown.getMessage().contains("Cannot convert"));
     }
 
     @Test
     void testBooleanConversionFromBooleanObject() throws IOException {
         // Direct Boolean value → convertToBoolean returns as-is
-        Object result = converter.getConvertedValue(null, Boolean.class, Boolean.TRUE, false);
+        Object result = strict.getConvertedValue(null, Boolean.class, Boolean.TRUE);
         assertEquals(Boolean.TRUE, result);
     }
 
     @Test
     void testBooleanConversionFromStringNo() throws IOException {
-        Object result = converter.getConvertedValue(null, boolean.class, "no", false);
+        Object result = strict.getConvertedValue(null, boolean.class, "no");
         assertEquals(Boolean.FALSE, result);
     }
 
@@ -107,14 +108,14 @@ class TypeConverterDirectTest {
     void testCollectionWithLenientFalseDoesNotConvertSingleValue() {
         // Single String value, Collection expectedType, but NOT lenient → should fall through
         IOException thrown = assertThrows(IOException.class, () ->
-                converter.getConvertedValue(null, List.class, "single", false));
+                strict.getConvertedValue(null, List.class, "single"));
         assertTrue(thrown.getMessage().contains("I cannot figure out how to retrieve this type"));
     }
 
     @Test
     void testCollectionWithLenientTrueConvertsSingleValue() throws IOException {
         // Single String value, Collection expectedType, lenient → wraps in List
-        Object result = converter.getConvertedValue(null, List.class, "single", true);
+        Object result = lenient.getConvertedValue(null, List.class, "single");
         assertInstanceOf(List.class, result);
         assertEquals(List.of("single"), result);
     }
@@ -124,13 +125,13 @@ class TypeConverterDirectTest {
     @Test
     void testConvertWithTypeNullForPrimitiveThrows() {
         IOException thrown = assertThrows(IOException.class, () ->
-                converter.convertWithType(int.class, null, false));
+                strict.convertWithType(int.class, null));
         assertEquals("Cannot assign null to primitive type int", thrown.getMessage());
     }
 
     @Test
     void testConvertWithTypeNullForNonPrimitiveReturnsNull() throws IOException {
-        Object result = converter.convertWithType(String.class, null, false);
+        Object result = strict.convertWithType(String.class, null);
         assertNull(result);
     }
 
@@ -139,7 +140,7 @@ class TypeConverterDirectTest {
         // Map value with raw Map.class type (no parameterized type info)
         Map<String, Object> mapValue = new LinkedHashMap<>();
         mapValue.put("key", "value");
-        Object result = converter.convertWithType(Map.class, mapValue, false);
+        Object result = strict.convertWithType(Map.class, mapValue);
         assertInstanceOf(Map.class, result);
     }
 
@@ -147,13 +148,13 @@ class TypeConverterDirectTest {
     void testConvertWithTypeCollectionWithRawClass() throws IOException {
         // Collection value with raw List.class type (no parameterized type info)
         List<String> listValue = List.of("a", "b");
-        Object result = converter.convertWithType(List.class, listValue, false);
+        Object result = strict.convertWithType(List.class, listValue);
         assertInstanceOf(List.class, result);
     }
 
     @Test
     void testConvertWithTypeScalar() throws IOException {
-        Object result = converter.convertWithType(String.class, "hello", false);
+        Object result = strict.convertWithType(String.class, "hello");
         assertEquals("hello", result);
     }
 
@@ -169,7 +170,7 @@ class TypeConverterDirectTest {
     void testHandleCollectionValueWithRawListField() throws Exception {
         // Raw List field (no parameterized type) — element type falls through to Object.
         java.lang.reflect.Field rawList = RawFieldFixture.class.getField("rawList");
-        Object result = converter.getConvertedValue(rawList, List.class, List.of("a", "b"), false);
+        Object result = strict.getConvertedValue(rawList, List.class, List.of("a", "b"));
         assertEquals(List.of("a", "b"), result);
     }
 
@@ -179,7 +180,7 @@ class TypeConverterDirectTest {
         java.lang.reflect.Field rawMap = RawFieldFixture.class.getField("rawMap");
         Map<String, String> input = new LinkedHashMap<>();
         input.put("k", "v");
-        Object result = converter.getConvertedValue(rawMap, Map.class, input, false);
+        Object result = strict.getConvertedValue(rawMap, Map.class, input);
         assertEquals(input, result);
     }
 
@@ -289,7 +290,7 @@ class TypeConverterDirectTest {
         recordMap.put("zip_code", null); // int cannot be null
 
         IOException thrown = assertThrows(IOException.class, () ->
-                converter.getConvertedValue(null, Address.class, recordMap, false));
+                strict.getConvertedValue(null, Address.class, recordMap));
         assertTrue(thrown.getMessage().contains("Cannot assign null to primitive record component 'zipCode'"));
     }
 
@@ -306,7 +307,7 @@ class TypeConverterDirectTest {
         recordMap.put("name", "Student");
         recordMap.put("scores", innerMap);
 
-        Object result = converter.getConvertedValue(null, RecordWithMap.class, recordMap, false);
+        Object result = strict.getConvertedValue(null, RecordWithMap.class, recordMap);
         assertInstanceOf(RecordWithMap.class, result);
         RecordWithMap converted = (RecordWithMap) result;
         assertEquals("Student", converted.name());
@@ -322,7 +323,7 @@ class TypeConverterDirectTest {
         recordMap.put("name", "Item");
         recordMap.put("tags", tags);
 
-        Object result = converter.getConvertedValue(null, RecordWithList.class, recordMap, false);
+        Object result = strict.getConvertedValue(null, RecordWithList.class, recordMap);
         assertInstanceOf(RecordWithList.class, result);
         RecordWithList converted = (RecordWithList) result;
         assertEquals("Item", converted.name());
@@ -335,34 +336,34 @@ class TypeConverterDirectTest {
     void testNumberToUnsupportedTypeThrows() {
         // Number value but expectedType is not a numeric type
         IOException thrown = assertThrows(IOException.class, () ->
-                converter.getConvertedValue(null, UUID.class, 42, false));
+                strict.getConvertedValue(null, UUID.class, 42));
         assertTrue(thrown.getMessage().contains("Cannot convert Integer to UUID"));
     }
 
     @Test
     void testFloatConversionLenientAllowsPrecisionLoss() throws IOException {
         // Double that can't be exactly represented as float, but lenient mode allows it
-        Object result = converter.getConvertedValue(null, float.class, 1.234567890123, true);
+        Object result = lenient.getConvertedValue(null, float.class, 1.234567890123);
         assertInstanceOf(Float.class, result);
     }
 
     @Test
     void testFloatConversionStrictRejectsPrecisionLoss() {
         IOException thrown = assertThrows(IOException.class, () ->
-                converter.getConvertedValue(null, float.class, 1.234567890123, false));
+                strict.getConvertedValue(null, float.class, 1.234567890123));
         assertTrue(thrown.getMessage().contains("cannot be precisely represented as a float"));
     }
 
     @Test
     void testCharacterConversionLenientTakesFirstChar() throws IOException {
-        Object result = converter.getConvertedValue(null, char.class, "abc", true);
+        Object result = lenient.getConvertedValue(null, char.class, "abc");
         assertEquals('a', result);
     }
 
     @Test
     void testCharacterConversionStrictRejectsMultiChar() {
         IOException thrown = assertThrows(IOException.class, () ->
-                converter.getConvertedValue(null, char.class, "abc", false));
+                strict.getConvertedValue(null, char.class, "abc"));
         assertTrue(thrown.getMessage().contains("Cannot convert String of length 3 to Character"));
     }
 
@@ -371,37 +372,37 @@ class TypeConverterDirectTest {
     @Test
     void testDoubleToIntegerConversion() throws IOException {
         // Double value being converted to Integer.class → hits the Integer.class branch in convertToNumber
-        Object result = converter.getConvertedValue(null, Integer.class, 42.0, false);
+        Object result = strict.getConvertedValue(null, Integer.class, 42.0);
         assertEquals(42, result);
     }
 
     @Test
     void testDoubleToLongConversion() throws IOException {
-        Object result = converter.getConvertedValue(null, Long.class, 42.0, false);
+        Object result = strict.getConvertedValue(null, Long.class, 42.0);
         assertEquals(42L, result);
     }
 
     @Test
     void testDoubleToShortConversion() throws IOException {
-        Object result = converter.getConvertedValue(null, Short.class, 42.0, false);
+        Object result = strict.getConvertedValue(null, Short.class, 42.0);
         assertEquals((short) 42, result);
     }
 
     @Test
     void testDoubleToByteConversion() throws IOException {
-        Object result = converter.getConvertedValue(null, Byte.class, 42.0, false);
+        Object result = strict.getConvertedValue(null, Byte.class, 42.0);
         assertEquals((byte) 42, result);
     }
 
     @Test
     void testIntToDoubleConversion() throws IOException {
-        Object result = converter.getConvertedValue(null, Double.class, 42, false);
+        Object result = strict.getConvertedValue(null, Double.class, 42);
         assertEquals(42.0, result);
     }
 
     @Test
     void testIntToFloatConversion() throws IOException {
-        Object result = converter.getConvertedValue(null, Float.class, 42, false);
+        Object result = strict.getConvertedValue(null, Float.class, 42);
         assertEquals(42.0f, result);
     }
 
@@ -431,7 +432,7 @@ class TypeConverterDirectTest {
         mapValue.put("key1", 10);
         mapValue.put("key2", 20);
 
-        Object result = converter.convertWithType(mapType, mapValue, false);
+        Object result = strict.convertWithType(mapType, mapValue);
         assertInstanceOf(Map.class, result);
         Map<?, ?> resultMap = (Map<?, ?>) result;
         assertEquals(10, resultMap.get("key1"));
@@ -458,7 +459,7 @@ class TypeConverterDirectTest {
         };
 
         List<String> listValue = List.of("a", "b");
-        Object result = converter.convertWithType(listType, listValue, false);
+        Object result = strict.convertWithType(listType, listValue);
         assertInstanceOf(List.class, result);
         assertEquals(2, ((List<?>) result).size());
     }
@@ -488,7 +489,7 @@ class TypeConverterDirectTest {
         Map<String, Object> mapValue = new LinkedHashMap<>();
         mapValue.put("key", "value");
 
-        Object result = converter.convertWithType(rawMapType, mapValue, false);
+        Object result = strict.convertWithType(rawMapType, mapValue);
         assertInstanceOf(Map.class, result);
     }
 
@@ -512,7 +513,7 @@ class TypeConverterDirectTest {
         };
 
         List<String> listValue = List.of("a", "b");
-        Object result = converter.convertWithType(rawListType, listValue, false);
+        Object result = strict.convertWithType(rawListType, listValue);
         assertInstanceOf(List.class, result);
     }
 
@@ -539,7 +540,7 @@ class TypeConverterDirectTest {
         Map<String, Object> mapValue = new LinkedHashMap<>();
         mapValue.put("key", "value");
 
-        Object result = converter.convertWithType(singleArgMapType, mapValue, false);
+        Object result = strict.convertWithType(singleArgMapType, mapValue);
         assertInstanceOf(Map.class, result);
     }
 
@@ -553,7 +554,7 @@ class TypeConverterDirectTest {
         recordMap.put("value", -1);
 
         IOException thrown = assertThrows(IOException.class, () ->
-                converter.getConvertedValue(null, ValidatingRecord.class, recordMap, false));
+                strict.getConvertedValue(null, ValidatingRecord.class, recordMap));
         assertTrue(thrown.getMessage().contains("Failed to instantiate record ValidatingRecord"));
     }
 
@@ -569,7 +570,7 @@ class TypeConverterDirectTest {
         recordMap.put("zip_code", 12345);
 
         // String has a String(String) constructor, so Map.toString() will be used
-        Object result = converter.getConvertedValue(null, Address.class, recordMap, false);
+        Object result = strict.getConvertedValue(null, Address.class, recordMap);
         assertInstanceOf(Address.class, result);
         // The map's toString becomes the street value
         Address addr = (Address) result;
@@ -589,6 +590,6 @@ class TypeConverterDirectTest {
 
         // Falls through to else block, then getConvertedValue tries to create String collection → fails
         assertThrows(IOException.class, () ->
-                converter.getConvertedValue(null, Address.class, recordMap, false));
+                strict.getConvertedValue(null, Address.class, recordMap));
     }
 }

--- a/src/test/java/org/avarion/yaml/testClasses/KeepNamingClass.java
+++ b/src/test/java/org/avarion/yaml/testClasses/KeepNamingClass.java
@@ -12,7 +12,7 @@ import org.avarion.yaml.YamlKey;
 public class KeepNamingClass extends YamlFileInterface {
 
     @YamlKey
-    public NamingRecord derivedBlock = NamingRecord.sample();
+    public NamingRecord derivedBlock = new NamingRecord("a", "b", "c", "d", "e");
 
     @YamlKey("anExplicitFieldKey")
     public String explicitField = "kept";

--- a/src/test/java/org/avarion/yaml/testClasses/NamingRecord.java
+++ b/src/test/java/org/avarion/yaml/testClasses/NamingRecord.java
@@ -16,8 +16,4 @@ public record NamingRecord(
         String name,
 
         @YamlKey("someCamelKey") String explicit) {
-
-    public static NamingRecord sample() {
-        return new NamingRecord("a", "b", "c", "d", "e");
-    }
 }

--- a/src/test/java/org/avarion/yaml/testClasses/SnakeCaseNamingClass.java
+++ b/src/test/java/org/avarion/yaml/testClasses/SnakeCaseNamingClass.java
@@ -10,7 +10,7 @@ import org.avarion.yaml.YamlKey;
 public class SnakeCaseNamingClass extends YamlFileInterface {
 
     @YamlKey
-    public NamingRecord derivedBlock = NamingRecord.sample();
+    public NamingRecord derivedBlock = new NamingRecord("a", "b", "c", "d", "e");
 
     @YamlKey("anExplicitFieldKey")
     public String explicitField = "kept";


### PR DESCRIPTION
Follow-up to #140 — cuts complexity introduced there, no behaviour change. 263 tests still pass.

**`Naming#convert`** — removed the 8-line fast-path (4 comment, 4 code) that skipped the regexes for identifiers with no capital. It dodged two `Matcher` allocations in a path that already does reflection and file I/O once per field; the regex path returns the same answer.

**`YamlKey` / `YamlComment`** — added `ElementType.RECORD_COMPONENT` to `@Target`, so the annotation is readable straight off the `RecordComponent`. That deletes `RecordComponents#annotationOn`, which scanned the declaring record's fields to find the component's backing field. Its javadoc justified the scan as compatibility with records compiled against an older release — but component annotations did nothing before #140, so that case has no users. Field annotations on regular classes are unaffected.

**`TypeConverter`** — `naming` was threaded through 8 signatures and ~14 call sites to reach one use in `convertMapToRecord`, plus 42 repetitions of `, Naming.SNAKE_CASE` in `TypeConverterDirectTest`. It is now a final field set by Lombok's `@RequiredArgsConstructor`, the same shape `YamlWriter` already uses.

**Tests** — dropped `testExplicitKeysStayVerbatimUnder{SnakeCase,Keep}`, which assert substrings of output the two tests directly above already assert byte-for-byte, and inlined `NamingRecord#sample()` at its two call sites.

Net: -47 lines.