### PR TITLE
ci: mirror docs into the wiki on release

### DIFF
--- a/.github/workflows/publish-docs-to-wiki.yml
+++ b/.github/workflows/publish-docs-to-wiki.yml
@@ -1,0 +1,43 @@
+name: Publish docs to wiki
+
+# The wiki mirrors docs/ as of the released tag, so readers never see documentation
+# for something that isn't out yet.
+on:
+  release:
+    types: [ published ]
+
+permissions:
+  contents: write
+
+jobs:
+  wiki:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Mirror docs into the wiki
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git clone --depth 1 "https://x-access-token:$TOKEN@github.com/${{ github.repository }}.wiki.git" wiki
+
+          # A mirror, not a merge: pages edited by hand in the wiki are replaced on every release.
+          rm -f wiki/*.md
+          cp docs/*.md wiki/
+          cp README.md wiki/Home.md
+
+          # Wiki pages are addressed by bare name, so strip the docs/ prefix and the .md extension.
+          # Same-page anchors like ](#naming-strategy) have no .md and are left alone.
+          sed -i -E 's@\]\((docs/)?([a-z-]+)\.md(#[^)]*)?\)@](\2\3)@g' wiki/*.md
+
+          cd wiki
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git diff --cached --quiet || git commit -m "docs: sync from $TAG"
+          git push


### PR DESCRIPTION
Publishes `docs/` to the GitHub wiki whenever a release is published.

Triggered on `release: published` and checked out at `github.event.release.tag_name`, so the wiki always shows the docs **as of the released tag** — never unreleased changes on master. That's the reason this isn't GitHub Pages: Pages' deploy-from-branch mode serves master continuously, and pinning it to a tag requires deploying through Actions with a Jekyll build step, which is more machinery than this.

**How it works** — a wiki is just a git repo, so no marketplace action is needed:
1. clone `<repo>.wiki.git`
2. copy `docs/*.md`, plus `README.md` as `Home.md`
3. rewrite links to bare wiki page names (`](docs/records.md)` and `](advanced.md#leniency-modes)` become `](records)` and `](advanced#leniency-modes)`; same-page anchors like `](#naming-strategy)` are left alone)
4. commit and push, skipping the commit when nothing changed

I ran the rewrite against the real docs: all 12 relative links resolve to one of the six pages, and no `.md` target survives.

### ⚠️ Two manual steps before this can run

1. **Enable the wiki** — currently `has_wiki: false` on this repo (Settings → Features → Wikis).
2. **Create one page by hand** in the wiki UI. The wiki git repo does not exist until the first page is created, so the `git clone` fails until then.

Until both are done the job will fail on its first release. Nothing else in the release process changes.

### Tradeoff worth knowing

This is a **mirror, not a merge** — `rm -f wiki/*.md` runs before the copy, so anything hand-edited in the wiki is replaced on the next release. That's deliberate: it keeps `docs/` the single reviewable source of truth. If you'd rather allow wiki-only pages, drop the `rm` and they'll survive (at the cost of deleted docs lingering).