### PR TITLE
fix: drop the backtracking trailing-whitespace regex

### DIFF
--- a/src/main/java/org/avarion/yaml/YamlFileInterface.java
+++ b/src/main/java/org/avarion/yaml/YamlFileInterface.java
@@ -312,7 +312,7 @@ public abstract class YamlFileInterface {
 
     private void appendHeaderComment(StringBuilder result, String header) {
         for (String line : header.split("\\r?\\n")) {
-            result.append("# ").append(line.replaceAll("\\s*$", "")).append("\n");
+            result.append("# ").append(line.stripTrailing()).append("\n");
         }
     }
 

--- a/src/main/java/org/avarion/yaml/YamlWriter.java
+++ b/src/main/java/org/avarion/yaml/YamlWriter.java
@@ -271,7 +271,7 @@ class YamlWriter {
         }
 
         for (String line : comment.split("\\r?\\n")) {
-            yaml.append(indent).append("# ").append(line.replaceAll("\\s*$", "")).append("\n");
+            yaml.append(indent).append("# ").append(line.stripTrailing()).append("\n");
         }
     }
 }

--- a/src/test/java/org/avarion/yaml/CoverageBoostTests.java
+++ b/src/test/java/org/avarion/yaml/CoverageBoostTests.java
@@ -132,7 +132,8 @@ class CoverageBoostTests extends TestCommon {
         }
 
         NonComparableSetConfig config = new NonComparableSetConfig();
-        // UUIDs are Comparable, so let's use a List instead to verify the path
+        // UUID is Comparable, so this covers the sorting side of normalizeCollection.
+        // The non-Comparable side is covered by YamlWriterEdgeCaseTests.
         UUID uuid1 = UUID.fromString("00000000-0000-0000-0000-000000000001");
         UUID uuid2 = UUID.fromString("00000000-0000-0000-0000-000000000002");
         config.items.add(uuid1);

--- a/src/test/java/org/avarion/yaml/YamlWriterEdgeCaseTests.java
+++ b/src/test/java/org/avarion/yaml/YamlWriterEdgeCaseTests.java
@@ -1,5 +1,6 @@
 package org.avarion.yaml;
 
+import org.avarion.yaml.testClasses.Address;
 import org.avarion.yaml.testClasses.EdgeCaseClass;
 import org.avarion.yaml.testClasses.StaticFieldTestClass;
 import org.junit.jupiter.api.Test;
@@ -125,6 +126,33 @@ class YamlWriterEdgeCaseTests extends TestCommon {
 
         // The normalization should handle empty sets
         assertDoesNotThrow(() -> config.save(target));
+    }
+
+    @Test
+    void testNormalizeCollectionWithNonComparableSet() throws IOException {
+        // Records don't implement Comparable, so normalizeCollection must skip the sort
+        // rather than blow up on the cast.
+        class NonComparableSetConfig extends YamlFileInterface {
+            @YamlKey("items")
+            public Set<Address> items = new LinkedHashSet<>();
+        }
+
+        NonComparableSetConfig config = new NonComparableSetConfig();
+        // Deliberately not in sorted order: if the sort ever ran, the output below would flip.
+        config.items.add(new Address("2 Second St", "Springfield", 22222));
+        config.items.add(new Address("1 First St", "Shelbyville", 11111));
+
+        config.save(target);
+
+        assertEquals("""
+                items:
+                  - street: 2 Second St
+                    city: Springfield
+                    zip_code: 22222
+                  - street: 1 First St
+                    city: Shelbyville
+                    zip_code: 11111
+                """, readFile());
     }
 
     enum TestEnum { VALUE_A, VALUE_B }

--- a/src/test/java/org/avarion/yaml/YamlWriterEdgeCaseTests.java
+++ b/src/test/java/org/avarion/yaml/YamlWriterEdgeCaseTests.java
@@ -127,27 +127,6 @@ class YamlWriterEdgeCaseTests extends TestCommon {
         assertDoesNotThrow(() -> config.save(target));
     }
 
-    @Test
-    void testNormalizeCollectionWithNonComparableSet() {
-        // Create a set with non-comparable objects
-        class NonComparable {
-            final String value;
-            NonComparable(String value) { this.value = value; }
-        }
-
-        // This tests the path where Set elements are not Comparable
-        Set<NonComparable> nonComparableSet = new LinkedHashSet<>();
-        nonComparableSet.add(new NonComparable("a"));
-        nonComparableSet.add(new NonComparable("b"));
-
-        // Should not throw when normalizing non-comparable set
-        // (The normalizeCollection should just convert to ArrayList without sorting)
-        assertDoesNotThrow(() -> {
-            List<?> normalized = new ArrayList<>(nonComparableSet);
-            assertEquals(2, normalized.size());
-        });
-    }
-
     enum TestEnum { VALUE_A, VALUE_B }
 
     @Test


### PR DESCRIPTION
Clears the two Sonar findings on master that are worth code changes. 263 tests green.

### Fixed — the two MAJOR regex findings

`YamlFileInterface:315` and `YamlWriter:274` both did `line.replaceAll("\\s*$", "")` to trim a comment line. Sonar is right that it's super-linear. The stdlib has done this since Java 11 and the project targets 17:

```java
line.replaceAll("\\s*$", "")  ->  line.stripTrailing()
```

No regex engine, clearer intent, and `stripTrailing()` uses `Character.isWhitespace` so it also catches Unicode whitespace that the ASCII-only `\s` class misses.

### Fixed — the MINOR "unused collection", by making the test real

`YamlWriterEdgeCaseTests.testNormalizeCollectionWithNonComparableSet` built a `Set`, then asserted on `new ArrayList<>(nonComparableSet)` — **it never called `save()`**, so it covered the JDK's ArrayList constructor rather than `normalizeCollection`. That's what Sonar's "unused collection" was pointing at.

Rather than delete it, it now does what its name says: saves a `Set<Address>` (records aren't `Comparable`) and asserts the insertion order survives, since a set that can't be sorted must be written as it came in.

Verified it actually guards the branch — dropping the `instanceof Comparable` check from `normalizeCollection` makes it fail with a `ClassCastException` rather than pass quietly.

### Not changed — two I'd suppress instead

**`TypeConverter:79`, cognitive complexity 21.** This is the flat dispatch table deliberately left alone in #143: fourteen sequential `if (...) return ...;` guards with zero nesting, whose *order* is the meaning. It was WONTFIX'd before, and only reappeared because #141 shifted its declaration line and Sonar lost the issue↔suppression match. Worth re-marking WONTFIX rather than splitting.

**`PluginLoggerRoutingTest:63`, unused parameter `args`.** `VarargsStyleLogger.warning(String, Object...)` exists precisely so `discoverPluginSink` can find that signature by reflection — the unused parameter *is* the thing under test. Removing it deletes the test's reason to exist. Worth marking false-positive.

### Also

Corrected the `CoverageBoostTests.testNonComparableSetInYaml` comment, which said "UUIDs are Comparable, so let's use a List instead to verify the path" while using a `Set<UUID>`. It covers the *sorting* side; the comment now says so and points at the test that covers the other side.