### PR TITLE
fix: clear the warning-sink ThreadLocal and drop dead test state

### DIFF
--- a/src/main/java/org/avarion/yaml/TypeConverter.java
+++ b/src/main/java/org/avarion/yaml/TypeConverter.java
@@ -23,21 +23,33 @@ final class TypeConverter {
     static final Logger LOG = Logger.getLogger(TypeConverter.class.getName());
 
     /**
-     * Per-thread sink for lenient warnings. Always non-null — defaults to {@link #LOG}'s
-     * {@code warning(String)} so callers don't need to null-check.
-     * {@link YamlFileInterface#load(Object)} replaces it with the plugin's logger for the
-     * duration of the load.
+     * Per-thread sink for lenient warnings, unset unless a caller installs one.
+     * {@link YamlFileInterface#load(Object)} installs the plugin's logger for the duration
+     * of the load, then restores what was there before.
      */
-    private static final ThreadLocal<Consumer<String>> ACTIVE = ThreadLocal.withInitial(() -> LOG::warning);
+    private static final ThreadLocal<Consumer<String>> ACTIVE = new ThreadLocal<>();
 
     static void warn(String message) {
-        ACTIVE.get().accept(message);
+        Consumer<String> sink = ACTIVE.get();
+        if (sink == null) {
+            LOG.warning(message);
+        } else {
+            sink.accept(message);
+        }
     }
 
-    /** Install {@code sink} for the current thread; returns the previous one for restore-in-finally. */
-    static Consumer<String> pushSink(@NotNull Consumer<String> sink) {
+    /**
+     * Install {@code sink} for the current thread; returns the previous one for restore-in-finally.
+     * A {@code null} sink clears the entry rather than parking a stale reference on a thread that
+     * may outlive the load — server thread pools are long-lived.
+     */
+    static @Nullable Consumer<String> pushSink(final @Nullable Consumer<String> sink) {
         Consumer<String> prev = ACTIVE.get();
-        ACTIVE.set(sink);
+        if (sink == null) {
+            ACTIVE.remove();
+        } else {
+            ACTIVE.set(sink);
+        }
         return prev;
     }
 

--- a/src/test/java/org/avarion/yaml/LeniencyTest.java
+++ b/src/test/java/org/avarion/yaml/LeniencyTest.java
@@ -4,7 +4,6 @@ import org.avarion.yaml.testClasses.Material;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;

--- a/src/test/java/org/avarion/yaml/testClasses/Sounds.java
+++ b/src/test/java/org/avarion/yaml/testClasses/Sounds.java
@@ -1,14 +1,27 @@
 package org.avarion.yaml.testClasses;
 
+import org.jetbrains.annotations.NotNull;
+
 /**
- * Constants looked up by static field name. Deliberately has no public String constructor and
- * no toString() override, so YamlWriter falls through to matching the value against a static
- * field. Instances carry no state -- the tests only ever compare identity.
+ * Mirrors a Minecraft-style registry constant: named instances reached through a static
+ * factory. Deliberately has no public String constructor and no toString() override, so
+ * YamlWriter falls through to matching the value against a static field.
  */
 public class Sounds {
-    public static final Sounds MY_SOUND_ROCKS = new Sounds();
-    public static final Sounds YOUR_SOUND_ROCKS_TOO = new Sounds();
+    public static final Sounds MY_SOUND_ROCKS = getSound("my.sound.rocks");
+    public static final Sounds YOUR_SOUND_ROCKS_TOO = getSound("your.sound.rocks.2");
 
-    private Sounds() {
+    private final String name;
+
+    private static @NotNull Sounds getSound(@NotNull String key) {
+        return new Sounds(key);
+    }
+
+    private Sounds(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
     }
 }

--- a/src/test/java/org/avarion/yaml/testClasses/Sounds.java
+++ b/src/test/java/org/avarion/yaml/testClasses/Sounds.java
@@ -1,18 +1,14 @@
 package org.avarion.yaml.testClasses;
 
-import org.jetbrains.annotations.NotNull;
-
+/**
+ * Constants looked up by static field name. Deliberately has no public String constructor and
+ * no toString() override, so YamlWriter falls through to matching the value against a static
+ * field. Instances carry no state -- the tests only ever compare identity.
+ */
 public class Sounds {
-    public static final Sounds MY_SOUND_ROCKS = getSound("my.sound.rocks");
-    public static final Sounds YOUR_SOUND_ROCKS_TOO = getSound("your.sound.rocks.2");
+    public static final Sounds MY_SOUND_ROCKS = new Sounds();
+    public static final Sounds YOUR_SOUND_ROCKS_TOO = new Sounds();
 
-    private final String name;
-
-    private static @NotNull Sounds getSound(@NotNull String key) {
-        return new Sounds(key);
-    }
-
-    private Sounds(String name) {
-        this.name = name;
+    private Sounds() {
     }
 }

--- a/src/test/java/org/avarion/yaml/testClasses/StaticFieldTestClass.java
+++ b/src/test/java/org/avarion/yaml/testClasses/StaticFieldTestClass.java
@@ -7,7 +7,10 @@ public class StaticFieldTestClass {
     // Public static field - should be found
     public static final StaticFieldTestClass PUBLIC_INSTANCE = new StaticFieldTestClass("public");
 
-    // Private static field - should NOT be found (not public)
+    // Private static field - should NOT be found (not public). Read only by reflection, in
+    // YamlWriter#getStaticFieldName: it is the sole case exercising the canAccess(null) == false
+    // branch, so deleting it drops that method from 8/8 to 7/8 branches covered.
+    @SuppressWarnings("unused")
     private static final StaticFieldTestClass PRIVATE_INSTANCE = new StaticFieldTestClass("private");
 
     // Public static but different value - should NOT match

--- a/src/test/java/org/bukkit/NamespacedKey.java
+++ b/src/test/java/org/bukkit/NamespacedKey.java
@@ -3,11 +3,21 @@ package org.bukkit;
 import net.kyori.adventure.key.Key;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Mirrors the shape of the real Bukkit NamespacedKey, including its namespace/key pair,
+ * so the reflective lookups in YamlWriter run against a realistic class.
+ */
 public final class NamespacedKey implements Key {
+    private final String ns;
     private final String key;
 
-    public NamespacedKey(String key) {
+    public NamespacedKey(String ns, String key) {
+        this.ns = ns;
         this.key = key;
+    }
+
+    public @NotNull String getNamespace() {
+        return ns;
     }
 
     @Override

--- a/src/test/java/org/bukkit/NamespacedKey.java
+++ b/src/test/java/org/bukkit/NamespacedKey.java
@@ -4,11 +4,9 @@ import net.kyori.adventure.key.Key;
 import org.jetbrains.annotations.NotNull;
 
 public final class NamespacedKey implements Key {
-    private final String ns;
     private final String key;
 
-    public NamespacedKey(String ns, String key) {
-        this.ns = ns;
+    public NamespacedKey(String key) {
         this.key = key;
     }
 

--- a/src/test/java/org/bukkit/SoundImpl.java
+++ b/src/test/java/org/bukkit/SoundImpl.java
@@ -13,7 +13,7 @@ public class SoundImpl implements Sound {
 
     @Override
     public @NotNull NamespacedKey getKey() {
-        return new NamespacedKey("sound", name);
+        return new NamespacedKey(name);
     }
 
     @Override

--- a/src/test/java/org/bukkit/SoundImpl.java
+++ b/src/test/java/org/bukkit/SoundImpl.java
@@ -13,7 +13,7 @@ public class SoundImpl implements Sound {
 
     @Override
     public @NotNull NamespacedKey getKey() {
-        return new NamespacedKey(name);
+        return new NamespacedKey("sound", name);
     }
 
     @Override


### PR DESCRIPTION
Fixes the 5 Sonar issues still open on master after the `setAccessible` ones were accepted. 263 tests green, branch coverage unchanged at 303/303.

## The real one

**`TypeConverter:31` — `Call "remove()" on "ACTIVE"`**

`ACTIVE` was a `ThreadLocal` created with `withInitial(...)` and only ever `set`, never `remove`d. `YamlFileInterface.load(Object)` installs the plugin's logger and restores the previous value in a `finally` — but "restoring" wrote the default back rather than clearing the entry, so every thread that ever loaded a config kept a sink referenced for its lifetime. On a server thread pool those threads outlive the load.

It now starts unset, `warn()` falls back to `LOG` when nothing is installed, and restoring a `null` sink calls `remove()`:

```java
static @Nullable Consumer<String> pushSink(final @Nullable Consumer<String> sink) {
    Consumer<String> prev = ACTIVE.get();
    if (sink == null) {
        ACTIVE.remove();
    } else {
        ACTIVE.set(sink);
    }
    return prev;
}
```

The existing `finally { pushSink(prev) }` call site needed no change — `prev` is now `null` on the first install, which clears the entry.

## Dead state removed

- **`LeniencyTest:7`** — unused `java.nio.file.Files` import.
- **`NamespacedKey:7`** — the `ns` field was assigned and never read. The double exists so `tryFormatAsKeyed` can call `key()` then `value()`; the namespace was never part of that. Field and constructor parameter dropped, and the single call site in `SoundImpl` updated.
- **`Sounds:9`** — same story. The tests only compare identity (`Sounds.MY_SOUND_ROCKS`), so the `name` field, the `getSound` factory and the `@NotNull` import all went. The class deliberately keeps *no* public `String` constructor and no `toString()` override — that is what makes `YamlWriter` fall through to static-field matching — so the comment now records it.

## Kept on purpose

**`StaticFieldTestClass:11` — `PRIVATE_INSTANCE`**

This one is a false positive worth explaining rather than obeying. The field is read only by reflection, from `YamlWriter#getStaticFieldName`, and it is the **only** case exercising the `field.canAccess(null) == false` branch.

Measured rather than assumed — deleting it:

```
getStaticFieldName BRANCH  covered=7 missed=1     (was 8/8)
```

So it stays, with `@SuppressWarnings("unused")` and a comment recording why, which is also what stops the issue reappearing.

## On the coverage numbers

A local build shows 2 uncovered lines in `YamlWrapperFactory` (the v1-vs-v2 selection). That is not a regression and not related to this change: only one SnakeYAML version can take that branch per run. Verified the union across `report-1.14.xml` and `report-2.4.xml` leaves **no** uncovered lines, which is why Sonar — aggregating all four reports — reports 100%.
