### PR TITLE
chore: let lombok generate the test and NestedMap boilerplate

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -160,7 +160,8 @@ dependencies {
     // lombok
     commonCompileOnly 'org.projectlombok:lombok:1.18.46'
     commonAnnotationProcessor 'org.projectlombok:lombok:1.18.46'
-    testImplementation 'org.projectlombok:lombok:1.18.46'
+    testCompileOnly 'org.projectlombok:lombok:1.18.46'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.46'
 }
 
 jar {

--- a/src/main/java/org/avarion/yaml/NestedMap.java
+++ b/src/main/java/org/avarion/yaml/NestedMap.java
@@ -1,5 +1,7 @@
 package org.avarion.yaml;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.avarion.yaml.exceptions.DuplicateKey;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -8,6 +10,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 class NestedMap {
+	@Getter
 	private final Map<Object, Object> map = new LinkedHashMap<>();
 
 	@SuppressWarnings("unchecked")
@@ -27,17 +30,9 @@ class NestedMap {
 		current.put(lastKey, new NestedNode(value, comment));
 	}
 
-	public Map<Object, Object> getMap() {
-		return map;
-	}
-
+	@RequiredArgsConstructor
 	public static class NestedNode {
 		public final Object value;
 		public final @Nullable String comment;
-
-		public NestedNode(@Nullable Object value, @Nullable String comment) {
-			this.value = value;
-			this.comment = comment;
-		}
 	}
 }

--- a/src/test/java/net/kyori/adventure/key/KeyImpl.java
+++ b/src/test/java/net/kyori/adventure/key/KeyImpl.java
@@ -1,13 +1,11 @@
 package net.kyori.adventure.key;
 
+import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.NotNull;
 
+@RequiredArgsConstructor
 public class KeyImpl implements Key {
     private final String name;
-
-    public KeyImpl(String name) {
-        this.name = name;
-    }
 
     @Override
     public @NotNull String value() {

--- a/src/test/java/org/avarion/yaml/PluginLoggerRoutingTest.java
+++ b/src/test/java/org/avarion/yaml/PluginLoggerRoutingTest.java
@@ -1,5 +1,7 @@
 package org.avarion.yaml;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.avarion.yaml.testClasses.Material;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -36,12 +38,11 @@ class PluginLoggerRoutingTest extends TestCommon {
     // ===== Plugin fixtures =====
 
     /** Bukkit/Spigot-style: getLogger() returns a real JUL Logger. */
+    @Getter
+    @RequiredArgsConstructor
     static class JulLoggerPlugin {
         private final File dataFolder;
         private final Logger logger;
-        public JulLoggerPlugin(File dataFolder, Logger logger) { this.dataFolder = dataFolder; this.logger = logger; }
-        public File getDataFolder() { return dataFolder; }
-        public Logger getLogger() { return logger; }
     }
 
     /** Modern-Paper-style: a fake logger exposing only {@code warn(String)}. */
@@ -49,12 +50,11 @@ class PluginLoggerRoutingTest extends TestCommon {
         final List<String> warnings = new ArrayList<>();
         public void warn(String message) { warnings.add(message); }
     }
+    @Getter
+    @RequiredArgsConstructor
     static class Slf4jPlugin {
         private final File dataFolder;
         private final Slf4jStyleLogger logger;
-        public Slf4jPlugin(File dataFolder, Slf4jStyleLogger logger) { this.dataFolder = dataFolder; this.logger = logger; }
-        public File getDataFolder() { return dataFolder; }
-        public Slf4jStyleLogger getLogger() { return logger; }
     }
 
     /** Log4j2/ALogger-style: only {@code warning(String, Object...)} varargs. */
@@ -62,36 +62,35 @@ class PluginLoggerRoutingTest extends TestCommon {
         final List<String> warnings = new ArrayList<>();
         public void warning(String message, Object... args) { warnings.add(message); }
     }
+    @Getter
+    @RequiredArgsConstructor
     static class VarargsPlugin {
         private final File dataFolder;
         private final VarargsStyleLogger logger;
-        public VarargsPlugin(File dataFolder, VarargsStyleLogger logger) { this.dataFolder = dataFolder; this.logger = logger; }
-        public File getDataFolder() { return dataFolder; }
-        public VarargsStyleLogger getLogger() { return logger; }
     }
 
     /** getLogger() is private — must be ignored by the public-method lookup. */
+    @Getter
+    @RequiredArgsConstructor
     static class PrivateLoggerPlugin {
         private final File dataFolder;
-        public PrivateLoggerPlugin(File dataFolder) { this.dataFolder = dataFolder; }
-        public File getDataFolder() { return dataFolder; }
         @SuppressWarnings("unused")
         private Logger getLogger() { return Logger.getLogger("private.should.be.ignored"); }
     }
 
     /** getLogger() returns an object with no warn/warning method — must fall back. */
+    @Getter
+    @RequiredArgsConstructor
     static class WrongLoggerTypePlugin {
         private final File dataFolder;
-        public WrongLoggerTypePlugin(File dataFolder) { this.dataFolder = dataFolder; }
-        public File getDataFolder() { return dataFolder; }
         public String getLogger() { return "not a Logger"; }
     }
 
     /** getLogger() returns null — must fall back. */
+    @Getter
+    @RequiredArgsConstructor
     static class NullLoggerPlugin {
         private final File dataFolder;
-        public NullLoggerPlugin(File dataFolder) { this.dataFolder = dataFolder; }
-        public File getDataFolder() { return dataFolder; }
         public Logger getLogger() { return null; }
     }
 
@@ -99,10 +98,10 @@ class PluginLoggerRoutingTest extends TestCommon {
     static class ThrowingLogger {
         public void warn(String message) { throw new RuntimeException("boom"); }
     }
+    @Getter
+    @RequiredArgsConstructor
     static class ThrowingLoggerPlugin {
         private final File dataFolder;
-        public ThrowingLoggerPlugin(File dataFolder) { this.dataFolder = dataFolder; }
-        public File getDataFolder() { return dataFolder; }
         public ThrowingLogger getLogger() { return new ThrowingLogger(); }
     }
 

--- a/src/test/java/org/avarion/yaml/testClasses/CustomNonStringAcceptingClass.java
+++ b/src/test/java/org/avarion/yaml/testClasses/CustomNonStringAcceptingClass.java
@@ -1,11 +1,10 @@
 package org.avarion.yaml.testClasses;
 
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
 public class CustomNonStringAcceptingClass {
     public int i;
-
-    public CustomNonStringAcceptingClass(final int i) {
-        this.i = i;
-    }
 
     @Override
     public String toString() {

--- a/src/test/java/org/avarion/yaml/testClasses/CustomStringAcceptingClass.java
+++ b/src/test/java/org/avarion/yaml/testClasses/CustomStringAcceptingClass.java
@@ -1,11 +1,10 @@
 package org.avarion.yaml.testClasses;
 
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
 public class CustomStringAcceptingClass {
     public String s;
-
-    public CustomStringAcceptingClass(final String s) {
-        this.s = s;
-    }
 
     @Override
     public String toString() {

--- a/src/test/java/org/avarion/yaml/testClasses/Sounds.java
+++ b/src/test/java/org/avarion/yaml/testClasses/Sounds.java
@@ -1,5 +1,8 @@
 package org.avarion.yaml.testClasses;
 
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -7,6 +10,8 @@ import org.jetbrains.annotations.NotNull;
  * factory. Deliberately has no public String constructor and no toString() override, so
  * YamlWriter falls through to matching the value against a static field.
  */
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class Sounds {
     public static final Sounds MY_SOUND_ROCKS = getSound("my.sound.rocks");
     public static final Sounds YOUR_SOUND_ROCKS_TOO = getSound("your.sound.rocks.2");
@@ -15,13 +20,5 @@ public class Sounds {
 
     private static @NotNull Sounds getSound(@NotNull String key) {
         return new Sounds(key);
-    }
-
-    private Sounds(String name) {
-        this.name = name;
-    }
-
-    public String getName() {
-        return name;
     }
 }

--- a/src/test/java/org/avarion/yaml/testClasses/StaticFieldTestClass.java
+++ b/src/test/java/org/avarion/yaml/testClasses/StaticFieldTestClass.java
@@ -1,8 +1,13 @@
 package org.avarion.yaml.testClasses;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
 /**
  * Test class with various static field configurations for testing getStaticFieldName
  */
+@Getter
+@RequiredArgsConstructor
 public class StaticFieldTestClass {
     // Public static field - should be found
     public static final StaticFieldTestClass PUBLIC_INSTANCE = new StaticFieldTestClass("public");
@@ -18,17 +23,9 @@ public class StaticFieldTestClass {
 
     private final String name;
 
-    public StaticFieldTestClass(String name) {
-        this.name = name;
-    }
-
     @Override
     public String toString() {
         // Return generic toString format to match the pattern in formatValue
         return getClass().getName() + "@" + Integer.toHexString(hashCode());
-    }
-
-    public String getName() {
-        return name;
     }
 }

--- a/src/test/java/org/bukkit/NamespacedKey.java
+++ b/src/test/java/org/bukkit/NamespacedKey.java
@@ -1,5 +1,6 @@
 package org.bukkit;
 
+import lombok.RequiredArgsConstructor;
 import net.kyori.adventure.key.Key;
 import org.jetbrains.annotations.NotNull;
 
@@ -7,14 +8,10 @@ import org.jetbrains.annotations.NotNull;
  * Mirrors the shape of the real Bukkit NamespacedKey, including its namespace/key pair,
  * so the reflective lookups in YamlWriter run against a realistic class.
  */
+@RequiredArgsConstructor
 public final class NamespacedKey implements Key {
     private final String ns;
     private final String key;
-
-    public NamespacedKey(String ns, String key) {
-        this.ns = ns;
-        this.key = key;
-    }
 
     public @NotNull String getNamespace() {
         return ns;

--- a/src/test/java/org/bukkit/SoundImpl.java
+++ b/src/test/java/org/bukkit/SoundImpl.java
@@ -1,15 +1,13 @@
 package org.bukkit;
 
+import lombok.RequiredArgsConstructor;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.key.KeyImpl;
 import org.jetbrains.annotations.NotNull;
 
+@RequiredArgsConstructor
 public class SoundImpl implements Sound {
     private final String name;
-
-    public SoundImpl(String name) {
-        this.name = name;
-    }
 
     @Override
     public @NotNull NamespacedKey getKey() {


### PR DESCRIPTION
Whole-library pass for boilerplate Lombok can generate. **-20 lines net (44 added, 64 removed)**, 263 tests green, branch coverage unchanged at 303/303.

## First: Lombok was never running in tests

Line 163 had `testImplementation 'org.projectlombok:lombok'`, which puts the jar on the compile classpath but does **not** register it as an annotation processor. I verified this the hard way before relying on it — swapping a hand-written `getName()` for `@Getter` compiled with **exit 0** and produced:

```
javap Sounds.class →   private final java.lang.String name;
```

No getter, no error. Any `@Getter` added to a test would have silently vanished and the "unused field" warning would have come straight back. Now:

```groovy
testCompileOnly 'org.projectlombok:lombok:1.18.46'
testAnnotationProcessor 'org.projectlombok:lombok:1.18.46'
```

`testCompileOnly` rather than `testImplementation` — Lombok has no business on the test *runtime* classpath.

## What was replaced

| Where | Replaced with |
|---|---|
| `NestedMap` | `@Getter` on `map`, `@RequiredArgsConstructor` on `NestedNode` |
| `PluginLoggerRoutingTest` — 7 plugin doubles | `@Getter` + `@RequiredArgsConstructor` |
| `SoundImpl`, `KeyImpl`, `NamespacedKey` | `@RequiredArgsConstructor` |
| `Sounds`, `StaticFieldTestClass` | `@Getter` + `@RequiredArgsConstructor` |
| `CustomStringAcceptingClass`, `CustomNonStringAcceptingClass` | `@AllArgsConstructor` |

The plugin doubles were the biggest win — seven near-identical classes of the form "two final fields, a constructor, two getters" collapse to two annotations each.

## Verification: the compiled API is unchanged

This codebase finds these classes *by reflection* — `getMethod("getLogger")`, `getConstructor(String.class)`, `getDeclaredFields()` — so "it compiles and tests pass" is not enough. I captured `javap -p` for all 16 affected classes before and after.

The raw diff shows only **reordering** (Lombok emits the constructor after the methods). Compared as sorted member sets:

```
diff  →  IDENTICAL member sets - no signature added, removed or altered
```

Same members, same access modifiers, same signatures — including that `Sounds`' constructor stays `private` and `PrivateLoggerPlugin.getLogger()` stays private so the public-method lookup still rejects it.

## What was deliberately left alone

- **Every custom `toString()`.** These are semantics, not boilerplate: `CustomStringAcceptingClass` returns the raw field, `StaticFieldTestClass` returns the generic `Class@hash` format that `formatValue`'s pattern matches, `SoundImpl` has its own format. `@ToString` would emit `Name(field=value)` and break them.
- **`Sounds` gets no `@ToString`.** It must keep inheriting `Object.toString()` — that generic format is exactly what makes `YamlWriter` fall through to static-field matching.
- **`NamespacedKey.getNamespace()` stays hand-written.** The field is `ns`, so `@Getter` would emit `getNs()` and lose the real Bukkit method name. (Renaming the field to `namespace` — which is what Bukkit actually calls it — would let Lombok generate it, if you'd prefer that.)
- **`PrivateYml`'s getters.** `getPriv()`/`getPub()`/`getNone()`/`getProt()` don't match their field names, so Lombok can't produce them.
- **No `@Data` or `@Value` anywhere.** Both would add `equals`/`hashCode`, and several tests compare fixture instances by identity.

## Coverage note

Line counters read `covered=477` vs `482` before, with `missed` unchanged at 2. That is 5 fewer lines *to* cover — the deleted boilerplate was all covered — not 5 newly uncovered lines. `getStaticFieldName` is still 8/8 branches, and overall branch coverage is unchanged at 303/303.
