### PR TITLE
feat: declared key renames, and a seam for adopting improved defaults

### DIFF
--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -303,6 +303,37 @@ Settings settings = new Settings().load(file);
 settings.renamesApplied();   // {mysql=database.mysql}
 ```
 
+### When the name stayed and the value moved on
+
+A rename is about a key. The mirror problem is about a value: a file beats the compile-time
+default for every key it has, which is what an operator's choice should do — and is also why a
+default that *improves* between releases never reaches anybody whose file already mentions it.
+
+Deciding whether a given line is a considered choice or an untouched copy of an older default
+needs to know what that older default was, and only the caller can know that. Acting on the
+answer is `load(File, Set<String>)`:
+
+```java
+Settings settings = new Settings().load(file, Set.of("loot.tier-items"));
+```
+
+An ignored key is not read, so the field keeps what it already holds — for a freshly built
+configuration object, this release's default. A following `save` writes that out, because it is
+what the field now says.
+
+Name keys the way their fields declare them, which `declaredKeys()` reports:
+
+```java
+new Settings().declaredKeys();   // [game.hub-world, loot.tier-items, database, ...]
+```
+
+One entry there may own a whole block, and ignoring it takes the block with it. That is
+deliberate: half a block read from the file and half from the defaults is a shape nobody asked
+for.
+
+Ignores are applied after renames, so a key stays ignored whether the value in it came from the
+file directly or was carried there by a declared move.
+
 ### Deleting a declaration
 
 Once the files in the wild have been through an upgrade, the write-back has already moved them,

--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -100,10 +100,11 @@ public String myField = "default";
 
 ### Attributes
 
-| Attribute | Type       | Default     | Description                                                       |
-|-----------|------------|-------------|--------------------------------------------------------------------|
-| `value`   | `String`   | `""`        | The YAML key path (supports dot notation for nesting). Empty means "derive it from the field name" |
-| `lenient` | `Leniency` | `UNDEFINED` | Leniency mode for this specific field                             |
+| Attribute    | Type       | Default     | Description                                                       |
+|--------------|------------|-------------|--------------------------------------------------------------------|
+| `value`      | `String`   | `""`        | The YAML key path (supports dot notation for nesting). Empty means "derive it from the field name" |
+| `lenient`    | `Leniency` | `UNDEFINED` | Leniency mode for this specific field                             |
+| `previously` | `String[]` | `{}`        | Keys this setting used to be spelled as, newest first — see [Keys that have moved](#keys-that-have-moved) |
 
 ### Bare @YamlKey
 
@@ -207,6 +208,110 @@ round-trips.
 Dot notation is **not** supported here — a record component is one key inside the record's
 own block, so it cannot spread itself over a nested path. A `@YamlKey` containing a `.` on a
 record component throws an `IOException` on both save and load.
+
+---
+
+## Keys that have moved
+
+A key that changes name between releases is not merely unread. `save` writes the file from the
+fields, so a key no field claims is dropped on the next write and the value under it goes with
+it. Declaring where a setting used to live turns that into a migration: before any field reads
+the file, the value is carried to the key it lives under now, and the write-back persists it
+there.
+
+### One key: `@YamlKey(previously = ...)`
+
+```java
+@YamlKey(value = "storm.damage-per-second", previously = "zone.damage-per-second")
+public double damage = 1.0;
+```
+
+```yaml
+# what the operator has                 # what they get back
+zone:                                   storm:
+  damage-per-second: 6.0                  damage-per-second: 6.0
+```
+
+List several when a setting has moved more than once, most recent first:
+
+```java
+@YamlKey(value = "hud.boss-bar.colour", previously = {"zone.bar.colour", "bar.colour"})
+public String colour = "RED";
+```
+
+The first old name the file actually has is the one used. Each entry is a full path from the
+root of the file, in the same dot notation as `value`.
+
+### A whole block: `@YamlRename`
+
+Some moves no field-level alias can express — where the old key's new home is inside a structure
+that no single field owns:
+
+```java
+@YamlFile
+@YamlRename(from = "mysql", to = "database.mysql")
+public class Settings extends YamlFileInterface {
+
+    @YamlKey("database")
+    public DatabaseSettings database = DatabaseSettings.mysql("avarion");
+}
+```
+
+```yaml
+# what the operator has                 # what they get back
+mysql:                                  database:
+  hostname: db.internal                   engine: 'MYSQL'
+  port: 3307                              mysql:
+  password: hunter2                         hostname: db.internal
+                                            port: 3307
+                                            password: hunter2
+```
+
+The credentials that used to be a top-level block are now one component of a record, beside an
+`engine` the old file never had. `engine` comes out at its default because
+[a record component the file does not set keeps its default](records.md). The annotation is
+repeatable, so a class can declare as many moves as its history needs.
+
+### The rules
+
+| Situation                       | What happens                                                         |
+|---------------------------------|----------------------------------------------------------------------|
+| only the old key is set         | the value is carried across, and the move is logged                  |
+| only the current key is set     | nothing happens, silently                                            |
+| both are set                    | the current key wins, out loud; the old one is dropped               |
+| the old key is set but empty    | nothing happens — an empty line is not a value to carry              |
+| neither is set                  | nothing happens, silently                                            |
+| the destination path is blocked | the move is refused, out loud, and the old key is left where it is   |
+
+That last one is the case where something on the way to the destination is already a value
+rather than a section. Overwriting it would destroy one setting to rescue another, so the move
+is refused instead.
+
+Class-level moves are applied before field-level ones — coarse before fine — so a field can name
+an old key that only exists once a block has landed. A base class's declarations are applied
+before its subclass's.
+
+### What moved
+
+`renamesApplied()` reports what the last load did: each old path the class declares, mapped to
+the key that now holds its value. A path is in there whether the value was carried across or the
+current key was already set and won — either way the old key was accounted for, which is what
+tells a caller not to report it as a setting that vanished for no reason.
+
+```java
+Settings settings = new Settings().load(file);
+settings.renamesApplied();   // {mysql=database.mysql}
+```
+
+### Deleting a declaration
+
+Once the files in the wild have been through an upgrade, the write-back has already moved them,
+and the declaration is doing nothing. Delete it a release or two later.
+
+Declare a rename only when the meaning did not change with the name. The value is carried across
+verbatim, so a key that changed *units* as it changed name — a radius that became a diameter —
+must not be declared: it would quietly halve every setting it touched. Those are for a one-off
+migration in the calling code, which can do the arithmetic.
 
 ---
 

--- a/docs/records.md
+++ b/docs/records.md
@@ -241,9 +241,46 @@ player:
     rank: Captain
 ```
 
+## Components the File Leaves Out
+
+A key the file omits leaves its field alone, and that rule does not stop at a record's edge. A
+component the YAML never mentions keeps whatever the target already held — for a settings class,
+its compile-time default:
+
+```java
+public record Credentials(String hostname, int port, String password) {}
+
+public record Database(Engine engine, Credentials mysql) {}
+
+public class Config extends YamlFileInterface {
+
+    @YamlKey("database")
+    public Database database =
+            new Database(Engine.MYSQL, new Credentials("db.default", 3306, "secret"));
+}
+```
+
+```yaml
+database:
+  mysql:
+    hostname: db.internal
+```
+
+loads as `Database(MYSQL, Credentials("db.internal", 3306, "secret"))` — the one setting the file
+states, and the defaults for everything it does not. The next `save` writes all of it out, so the
+gaps are filled in on disk too.
+
+This is what lets a block move into a record that has since grown a component (see
+[Keys that have moved](annotations.md#keys-that-have-moved)): the operator's old block arrives,
+and the component they never had comes from this release's defaults.
+
+Writing a key down empty is a different statement from leaving it out, and only the second is a
+question about defaults — see below.
+
 ## Null Values in Records
 
-Record components can be null (except primitives):
+Record components can be null (except primitives). A component whose key is present and empty is
+null, and stays null:
 
 ```java
 public record OptionalInfo(String required, String optional) {}

--- a/src/main/java/org/avarion/yaml/KeyRenames.java
+++ b/src/main/java/org/avarion/yaml/KeyRenames.java
@@ -48,20 +48,18 @@ final class KeyRenames {
             move(data, rename.from(), rename.to(), applied);
         }
 
-        for (Class<?> clazz = type; clazz != null; clazz = clazz.getSuperclass()) {
-            for (Field field : clazz.getDeclaredFields()) {
-                YamlKey annotation = field.getAnnotation(YamlKey.class);
-                if (annotation == null || annotation.previously().length == 0) {
-                    continue;
-                }
-                String to = YamlFileInterface.keyOf(field, annotation, naming);
-                for (String from : annotation.previously()) {
-                    // Newest first, and the first one the file actually has wins: a file holding
-                    // two generations of the same key was hand-edited across an upgrade, and the
-                    // later spelling is the better guess at what they meant.
-                    if (move(data, from, to, applied)) {
-                        break;
-                    }
+        for (Field field : YamlFileInterface.yamlKeyFields(type)) {
+            YamlKey annotation = field.getAnnotation(YamlKey.class);
+            if (annotation.previously().length == 0) {
+                continue;
+            }
+            String to = YamlFileInterface.keyOf(field, annotation, naming);
+            for (String from : annotation.previously()) {
+                // Newest first, and the first one the file actually has wins: a file holding
+                // two generations of the same key was hand-edited across an upgrade, and the
+                // later spelling is the better guess at what they meant.
+                if (move(data, from, to, applied)) {
+                    break;
                 }
             }
         }

--- a/src/main/java/org/avarion/yaml/KeyRenames.java
+++ b/src/main/java/org/avarion/yaml/KeyRenames.java
@@ -1,0 +1,199 @@
+package org.avarion.yaml;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.Field;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Carries settings from the keys they used to live under to the ones they live under now.
+ *
+ * <p>Applied to the parsed file before any field reads it, which is what makes it a migration
+ * rather than a read-through: the field is loaded from the new key, and the write-back then
+ * persists it there. A release or two later the declaration can be deleted and the files in the
+ * wild have already moved.
+ *
+ * <p>Two spellings, one mechanism. {@link YamlKey#previously()} moves one key; {@link YamlRename}
+ * on the class moves a whole block, which is the case a field-level alias cannot reach. Blocks
+ * move first, so a field can name an old key that only exists once a block has landed.
+ *
+ * @see YamlRename
+ */
+final class KeyRenames {
+
+    private KeyRenames() {
+    }
+
+    /**
+     * Move everything {@code type} declares as moved, in {@code data}, in place.
+     *
+     * @return every old path a declaration accounted for, mapped to the key that now holds the
+     * value — whether it was carried there or was already there. What it is <em>not</em> is a
+     * list of keys still needing a human: those are exactly the ones missing from it.
+     */
+    static @NotNull Map<String, String> applyTo(final @NotNull Map<String, Object> data,
+                                                final @NotNull Class<?> type,
+                                                final @NotNull Naming naming) {
+        Map<String, String> applied = new LinkedHashMap<>();
+
+        for (YamlRename rename : blockMovesOn(type)) {
+            move(data, rename.from(), rename.to(), applied);
+        }
+
+        for (Class<?> clazz = type; clazz != null; clazz = clazz.getSuperclass()) {
+            for (Field field : clazz.getDeclaredFields()) {
+                YamlKey annotation = field.getAnnotation(YamlKey.class);
+                if (annotation == null || annotation.previously().length == 0) {
+                    continue;
+                }
+                String to = YamlFileInterface.keyOf(field, annotation, naming);
+                for (String from : annotation.previously()) {
+                    // Newest first, and the first one the file actually has wins: a file holding
+                    // two generations of the same key was hand-edited across an upgrade, and the
+                    // later spelling is the better guess at what they meant.
+                    if (move(data, from, to, applied)) {
+                        break;
+                    }
+                }
+            }
+        }
+
+        return applied;
+    }
+
+    /**
+     * The block moves declared on {@code type} and everything it extends, base class first so a
+     * subclass's declaration is applied to a file its parent has already reshaped.
+     */
+    private static @NotNull List<YamlRename> blockMovesOn(final @NotNull Class<?> type) {
+        Deque<Class<?>> chain = new ArrayDeque<>();
+        for (Class<?> clazz = type; clazz != Object.class; clazz = clazz.getSuperclass()) {
+            chain.push(clazz);
+        }
+        List<YamlRename> moves = new ArrayList<>();
+        for (Class<?> clazz : chain) {
+            moves.addAll(Arrays.asList(clazz.getDeclaredAnnotationsByType(YamlRename.class)));
+        }
+        return moves;
+    }
+
+    /**
+     * Carry {@code from} to {@code to}, if {@code from} is there at all.
+     *
+     * @return whether the declaration accounted for {@code from} — either it moved, or {@code to}
+     * was already set and the old one was dropped in its favour. False means the file simply did
+     * not have it, or that the move could not be made.
+     */
+    private static boolean move(final @NotNull Map<String, Object> data, final @NotNull String rawFrom,
+                                final @NotNull String rawTo, final @NotNull Map<String, String> applied) {
+        String from = rawFrom.trim();
+        String to = rawTo.trim();
+        if (from.isEmpty() || to.isEmpty() || from.equals(to)) {
+            return false;
+        }
+
+        // The block holding `from` is looked up once and kept: it is both where the value is read
+        // and where it is taken out of, and asking twice would mean a second answer to null-check
+        // that cannot differ from the first.
+        Map<String, Object> origin = blockHolding(data, from, false);
+        String leaf = leafOf(from);
+        if (origin == null || origin.get(leaf) == null) {
+            // Absent, or written down empty. Neither is a value to carry anywhere.
+            return false;
+        }
+        Object value = origin.get(leaf);
+
+        if (valueAt(data, to) != YamlFileInterface.UNKNOWN) {
+            // Both generations in one file: somebody hand-edited across an upgrade. The key this
+            // release documents is the one to believe, and the other one is about to stop
+            // existing, so say which value is being used before it does.
+            TypeConverter.warn("'" + from + "' is now '" + to + "', and this file sets both."
+                               + " Using '" + to + "'; the value under '" + from + "' is ignored"
+                               + " and will not be kept.");
+            origin.remove(leaf);
+            applied.put(from, to);
+            return true;
+        }
+
+        if (!putAt(data, to, value)) {
+            // Something along the way to `to` is a value where a block has to be. Leaving `from`
+            // exactly where it is, is the point: untouched, it is still there to be reported as a
+            // key that belongs to nothing, which beats discarding it quietly.
+            TypeConverter.warn("'" + from + "' should have moved to '" + to + "', but '" + to
+                               + "' cannot be created: something on the way to it is a value"
+                               + " rather than a section. Fix that and the move will happen.");
+            return false;
+        }
+
+        origin.remove(leaf);
+        TypeConverter.warn("'" + from + "' is now '" + to + "'; your value has been carried across.");
+        applied.put(from, to);
+        return true;
+    }
+
+    // ==================== Walking a dotted path ====================
+
+    /** What sits at {@code path}, or {@link YamlFileInterface#UNKNOWN} when nothing does. */
+    private static @NotNull Object valueAt(final @NotNull Map<String, Object> data, final @NotNull String path) {
+        Map<String, Object> parent = blockHolding(data, path, false);
+        String leaf = leafOf(path);
+        if (parent == null || !parent.containsKey(leaf)) {
+            return YamlFileInterface.UNKNOWN;
+        }
+        Object value = parent.get(leaf);
+        return value == null ? YamlFileInterface.UNKNOWN : value;
+    }
+
+    /** Put {@code value} at {@code path}, reporting whether there was room for it. */
+    private static boolean putAt(final @NotNull Map<String, Object> data, final @NotNull String path,
+                                 final @NotNull Object value) {
+        Map<String, Object> parent = blockHolding(data, path, true);
+        if (parent == null) {
+            return false;
+        }
+        parent.put(leafOf(path), value);
+        return true;
+    }
+
+    /**
+     * The map that holds the last segment of {@code path}, or {@code null} when the way there is
+     * blocked.
+     *
+     * <p>With {@code create}, missing blocks along the way are made — but a segment that already
+     * holds a value rather than a block is never overwritten. Clobbering an operator's setting to
+     * make room for a rename would be a worse bug than the one renames exist to fix, so the move
+     * is refused instead and said out loud.
+     */
+    @SuppressWarnings("unchecked")
+    private static @Nullable Map<String, Object> blockHolding(final @NotNull Map<String, Object> data,
+                                                              final @NotNull String path, final boolean create) {
+        String[] parts = path.split("\\.");
+        Map<String, Object> current = data;
+        for (int i = 0; i < parts.length - 1; i++) {
+            Object next = current.get(parts[i]);
+            if (!(next instanceof Map)) {
+                // An absent key and one written down empty are both room to build in; anything
+                // else is somebody's setting.
+                if (!create || next != null) {
+                    return null;
+                }
+                next = new LinkedHashMap<String, Object>();
+                current.put(parts[i], next);
+            }
+            current = (Map<String, Object>) next;
+        }
+        return current;
+    }
+
+    private static @NotNull String leafOf(final @NotNull String path) {
+        int dot = path.lastIndexOf('.');
+        return dot < 0 ? path : path.substring(dot + 1);
+    }
+}

--- a/src/main/java/org/avarion/yaml/KeyRenames.java
+++ b/src/main/java/org/avarion/yaml/KeyRenames.java
@@ -11,6 +11,7 @@ import java.util.Deque;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Carries settings from the keys they used to live under to the ones they live under now.
@@ -136,6 +137,22 @@ final class KeyRenames {
         TypeConverter.warn("'" + from + "' is now '" + to + "'; your value has been carried across.");
         applied.put(from, to);
         return true;
+    }
+
+    /**
+     * Take {@code paths} and everything under them out of {@code data}, so the fields that claim
+     * them keep what they already hold.
+     *
+     * @see YamlFileInterface#load(java.io.File, Set)
+     */
+    static void drop(final @NotNull Map<String, Object> data, final @NotNull Set<String> paths) {
+        for (String path : paths) {
+            String trimmed = path.trim();
+            Map<String, Object> parent = blockHolding(data, trimmed, false);
+            if (parent != null) {
+                parent.remove(leafOf(trimmed));
+            }
+        }
     }
 
     // ==================== Walking a dotted path ====================

--- a/src/main/java/org/avarion/yaml/TypeConverter.java
+++ b/src/main/java/org/avarion/yaml/TypeConverter.java
@@ -82,22 +82,6 @@ final class TypeConverter {
     // ==================== Main Entry Points ====================
 
     /**
-     * Convert a value to the type specified by the field.
-     */
-    @Nullable Object getConvertedValue(final @NotNull Field field, final Object value) throws IOException {
-        return getConvertedValue(field, field.getType(), value, null);
-    }
-
-    /**
-     * Convert a value to the type specified by the field, keeping whatever {@code fallback}
-     * already holds for anything inside a record the YAML does not mention.
-     */
-    @Nullable Object getConvertedValue(final @NotNull Field field, final Object value, final @Nullable Object fallback)
-            throws IOException {
-        return getConvertedValue(field, field.getType(), value, fallback);
-    }
-
-    /**
      * Convert a value to the expected type with optional field context.
      */
     @Nullable Object getConvertedValue(final @Nullable Field field, final @NotNull Class<?> expectedType, final Object value)

--- a/src/main/java/org/avarion/yaml/TypeConverter.java
+++ b/src/main/java/org/avarion/yaml/TypeConverter.java
@@ -85,13 +85,34 @@ final class TypeConverter {
      * Convert a value to the type specified by the field.
      */
     @Nullable Object getConvertedValue(final @NotNull Field field, final Object value) throws IOException {
-        return getConvertedValue(field, field.getType(), value);
+        return getConvertedValue(field, field.getType(), value, null);
+    }
+
+    /**
+     * Convert a value to the type specified by the field, keeping whatever {@code fallback}
+     * already holds for anything inside a record the YAML does not mention.
+     */
+    @Nullable Object getConvertedValue(final @NotNull Field field, final Object value, final @Nullable Object fallback)
+            throws IOException {
+        return getConvertedValue(field, field.getType(), value, fallback);
     }
 
     /**
      * Convert a value to the expected type with optional field context.
      */
-    @Nullable Object getConvertedValue(final @Nullable Field field, final @NotNull Class<?> expectedType, final Object value) throws IOException {
+    @Nullable Object getConvertedValue(final @Nullable Field field, final @NotNull Class<?> expectedType, final Object value)
+            throws IOException {
+        return getConvertedValue(field, expectedType, value, null);
+    }
+
+    /**
+     * Convert a value to the expected type with optional field context.
+     *
+     * @param fallback what the target already holds, consulted only for a record component the
+     *                 YAML leaves out entirely; {@code null} when there is nothing to fall back on
+     */
+    @Nullable Object getConvertedValue(final @Nullable Field field, final @NotNull Class<?> expectedType, final Object value,
+                                       final @Nullable Object fallback) throws IOException {
         if (value == null) {
             return handleNullValue(expectedType, field);
         }
@@ -140,7 +161,7 @@ final class TypeConverter {
 
         // Handle Records: convert Map to Record using canonical constructor
         if (value instanceof Map && expectedType.isRecord()) {
-            return convertMapToRecord(expectedType, (Map<?, ?>) value);
+            return convertMapToRecord(expectedType, (Map<?, ?>) value, fallback);
         }
 
         // For other classes, attempt to use their constructor that takes a String parameter
@@ -213,6 +234,15 @@ final class TypeConverter {
      * For simple types, it delegates to getConvertedValue to avoid code duplication.
      */
     @Nullable Object convertWithType(final @NotNull Type type, final Object value) throws IOException {
+        return convertWithType(type, value, null);
+    }
+
+    /**
+     * As {@link #convertWithType(Type, Object)}, carrying what the target already holds so a
+     * record nested inside this one can keep the components the YAML leaves out.
+     */
+    @Nullable Object convertWithType(final @NotNull Type type, final Object value, final @Nullable Object fallback)
+            throws IOException {
         Class<?> rawClass = getRawClass(type);
 
         if (value == null) {
@@ -227,7 +257,7 @@ final class TypeConverter {
 
         // For all other types (primitives, String, enums, UUID, numbers, chars, etc.),
         // delegate to getConvertedValue which has all the conversion logic in one place.
-        return getConvertedValue(null, rawClass, value);
+        return getConvertedValue(null, rawClass, value, fallback);
     }
 
     // ==================== Collection & Map Handling ====================
@@ -306,13 +336,27 @@ final class TypeConverter {
      * Supports nested records: if a component is itself a record and the value is a Map,
      * it will recursively convert the nested Map to the nested record type.
      */
-    private @NotNull Object convertMapToRecord(final @NotNull Class<?> recordClass, final @NotNull Map<?, ?> map) throws IOException {
+    private @NotNull Object convertMapToRecord(final @NotNull Class<?> recordClass, final @NotNull Map<?, ?> map,
+                                               final @Nullable Object fallback) throws IOException {
         RecordComponent[] components = recordClass.getRecordComponents();
         Object[] args = new Object[components.length];
 
         for (int i = 0; i < components.length; i++) {
             RecordComponent component = components[i];
-            Object value = map.get(RecordComponents.keyOf(component, naming));
+            String key = RecordComponents.keyOf(component, naming);
+            Object existing = componentOf(recordClass, fallback, component);
+
+            // Not written down at all is not the same statement as written down
+            // empty: the first says nothing about this setting, so whatever the
+            // target already held stands, exactly as it would for a top-level
+            // field whose key the file omits. A key that IS present and null
+            // falls through and means null, primitives included.
+            if (!map.containsKey(key) && existing != null) {
+                args[i] = existing;
+                continue;
+            }
+
+            Object value = map.get(key);
 
             if (value == null && component.getType().isPrimitive()) {
                 throw new IOException("Cannot assign null to primitive record component '" + component.getName() +
@@ -321,7 +365,7 @@ final class TypeConverter {
 
             // convertWithType already routes nested records, maps and collections by their generic
             // type, so every non-null component takes the same road in.
-            args[i] = value == null ? null : convertWithType(component.getGenericType(), value);
+            args[i] = value == null ? null : convertWithType(component.getGenericType(), value, existing);
 
             // A record component cannot be skipped, so a lenient enum-skip becomes null
             if (args[i] == LENIENT_ENUM_SKIP) {
@@ -340,6 +384,29 @@ final class TypeConverter {
         }
         catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
             throw new IOException("Failed to instantiate record " + recordClass.getSimpleName() + ": " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * What {@code fallback} holds for one component, or {@code null} when there is nothing to
+     * ask — no fallback at all, or one that is not this record.
+     *
+     * <p>An accessor that refuses to answer is treated as no answer rather than as a failure to
+     * load: the component then takes the same road a component with no fallback takes, which is
+     * the behaviour of every release before fallbacks existed.
+     */
+    private static @Nullable Object componentOf(final @NotNull Class<?> recordClass, final @Nullable Object fallback,
+                                                final @NotNull RecordComponent component) {
+        if (!recordClass.isInstance(fallback)) {
+            return null;
+        }
+        try {
+            Method accessor = component.getAccessor();
+            accessor.setAccessible(true);
+            return accessor.invoke(fallback);
+        }
+        catch (ReflectiveOperationException | RuntimeException ignored) {
+            return null;
         }
     }
 

--- a/src/main/java/org/avarion/yaml/YamlFileInterface.java
+++ b/src/main/java/org/avarion/yaml/YamlFileInterface.java
@@ -247,12 +247,16 @@ public abstract class YamlFileInterface {
 
         Object value = getNestedValue(data, key.split("\\."));
         if (value != UNKNOWN) {
-            Object converted = convert(key, field, value, naming, isLenient);
+            field.setAccessible(true);
+            // Read before the conversion, because the conversion may need it: a
+            // record block the file only half fills in takes the rest from what
+            // the field already holds.
+            Object current = field.get(this);
+            Object converted = convert(key, field, value, naming, isLenient, current);
             if (converted == TypeConverter.LENIENT_ENUM_SKIP) {
                 // Lenient mode: bad enum value at top level — leave field at its default
                 return;
             }
-            field.setAccessible(true);
             field.set(this, converted);
         }
     }
@@ -264,12 +268,16 @@ public abstract class YamlFileInterface {
      * The converter is handed a {@link Field}, whose name is the Java one — the
      * reader is looking at a yaml file and needs the yaml one. This is the only
      * place a conversion is started, and the only one where both are in scope.
+     *
+     * @param current what the field holds now, which is what a record component
+     *                the file does not mention falls back to
      */
     private static Object convert(
-            @NotNull String key, @NotNull Field field, @NotNull Object value, @NotNull Naming naming, boolean isLenient)
+            @NotNull String key, @NotNull Field field, @NotNull Object value, @NotNull Naming naming, boolean isLenient,
+            @Nullable Object current)
             throws IOException {
         try {
-            return new TypeConverter(naming, isLenient).getConvertedValue(field, value);
+            return new TypeConverter(naming, isLenient).getConvertedValue(field, value, current);
         }
         catch (IOException e) {
             throw new IOException(key + ": " + e.getMessage(), e);

--- a/src/main/java/org/avarion/yaml/YamlFileInterface.java
+++ b/src/main/java/org/avarion/yaml/YamlFileInterface.java
@@ -96,7 +96,7 @@ public abstract class YamlFileInterface {
         // Before any field looks at the file, so a setting that has moved is read from where it
         // lives now and written back there — a migration rather than a value quietly lost to the
         // write-back.
-        renames = KeyRenames.applyTo(data, clazz, naming);
+        renames = Collections.unmodifiableMap(KeyRenames.applyTo(data, clazz, naming));
         KeyRenames.drop(data, ignoredKeys);
 
         try {
@@ -131,6 +131,8 @@ public abstract class YamlFileInterface {
     /**
      * What the last load did with keys that have moved: each old path this class declares, mapped
      * to the key that now holds its value.
+     *
+     * <p>Read-only: what a load did is a report, not a thing to edit.
      *
      * <p>Empty before any load, and after one that found nothing to move. A path appears here
      * whether its value was carried across or the new key was already set and won — either way

--- a/src/main/java/org/avarion/yaml/YamlFileInterface.java
+++ b/src/main/java/org/avarion/yaml/YamlFileInterface.java
@@ -100,7 +100,9 @@ public abstract class YamlFileInterface {
         KeyRenames.drop(data, ignoredKeys);
 
         try {
-            loadFields(data, isLenientByDefault, naming);
+            for (Field field : yamlKeyFields(clazz)) {
+                readYamlKeyField(data, field, isLenientByDefault, naming);
+            }
         } catch (IllegalAccessException | IllegalArgumentException | NullPointerException | FinalAttribute e) {
             throw new IOException(e);
         }
@@ -120,13 +122,8 @@ public abstract class YamlFileInterface {
     public @NotNull List<String> declaredKeys() {
         Naming naming = namingOf(this.getClass().getAnnotation(YamlFile.class));
         List<String> keys = new ArrayList<>();
-        for (Class<?> clazz = this.getClass(); clazz != null; clazz = clazz.getSuperclass()) {
-            for (Field field : clazz.getDeclaredFields()) {
-                YamlKey annotation = field.getAnnotation(YamlKey.class);
-                if (annotation != null) {
-                    keys.add(keyOf(field, annotation, naming));
-                }
-            }
+        for (Field field : yamlKeyFields(this.getClass())) {
+            keys.add(keyOf(field, field.getAnnotation(YamlKey.class), naming));
         }
         return keys;
     }
@@ -301,26 +298,35 @@ public abstract class YamlFileInterface {
 
     // ==================== Field Processing ====================
 
-    private void loadFields(@NotNull Map<String, Object> data, boolean isLenientByDefault, @NotNull Naming naming)
-            throws FinalAttribute, IllegalAccessException, IOException {
-        for (Class<?> clazz = this.getClass(); clazz != null; clazz = clazz.getSuperclass()) {
+    /**
+     * Every field in {@code type} and its superclasses that carries a {@link YamlKey},
+     * subclass first.
+     *
+     * <p>The one answer to which fields take part. Loading, saving, {@link #declaredKeys()}
+     * and {@link KeyRenames} all walk this list, so none of them can disagree about it — and
+     * such a disagreement is never harmless: a field only one side knows about is a setting
+     * that is read but not kept, or kept but never read.
+     */
+    static @NotNull List<Field> yamlKeyFields(final @NotNull Class<?> type) {
+        List<Field> fields = new ArrayList<>();
+        for (Class<?> clazz = type; clazz != null; clazz = clazz.getSuperclass()) {
             for (Field field : clazz.getDeclaredFields()) {
-                YamlKey keyAnnotation = field.getAnnotation(YamlKey.class);
-
-                if (keyAnnotation != null) {
-                    readYamlKeyField(data, field, keyAnnotation, isLenientByDefault, naming);
+                if (field.isAnnotationPresent(YamlKey.class)) {
+                    fields.add(field);
                 }
             }
         }
+        return fields;
     }
 
     private void readYamlKeyField(
-            Map<String, Object> data, @NotNull Field field, @NotNull YamlKey annotation, boolean isLenientByDefault, @NotNull Naming naming)
+            Map<String, Object> data, @NotNull Field field, boolean isLenientByDefault, @NotNull Naming naming)
             throws FinalAttribute, IllegalAccessException, IOException {
         if (Modifier.isFinal(field.getModifiers())) {
             throw new FinalAttribute(field.getName());
         }
 
+        YamlKey annotation = field.getAnnotation(YamlKey.class);
         String key = keyOf(field, annotation, naming);
         boolean isLenient = isLenient(annotation.lenient(), isLenientByDefault);
 
@@ -377,28 +383,23 @@ public abstract class YamlFileInterface {
             result.append("\n");
         }
 
-        // Fields, up the class hierarchy exactly as loadFields walks it. Reading further than
-        // writing is worse than either alone: an inherited key would be loaded from the file and
-        // then left out of what replaces it, so a load-then-save cycle deletes the setting along
-        // with whatever the operator had put in it.
+        // The same walk loading uses, so reading and writing cannot disagree about which
+        // fields take part. Reading further than writing would be worse than either alone: an
+        // inherited key would be loaded from the file and then left out of what replaces it,
+        // so a load-then-save cycle would delete the setting along with whatever the operator
+        // had put in it.
         Naming naming = namingOf(yamlFileAnnotation);
         NestedMap nestedMap = new NestedMap();
-        for (Class<?> owner = clazz; owner != null; owner = owner.getSuperclass()) {
-            for (Field field : owner.getDeclaredFields()) {
-                YamlKey keyAnnotation = field.getAnnotation(YamlKey.class);
-
-                if (keyAnnotation != null) {
-                    if (Modifier.isFinal(field.getModifiers())) {
-                        throw new FinalAttribute(field.getName());
-                    }
-
-                    field.setAccessible(true);
-                    Object value = field.get(this);
-                    YamlComment comment = field.getAnnotation(YamlComment.class);
-
-                    nestedMap.put(keyOf(field, keyAnnotation, naming), comment == null ? null : comment.value(), value);
-                }
+        for (Field field : yamlKeyFields(clazz)) {
+            if (Modifier.isFinal(field.getModifiers())) {
+                throw new FinalAttribute(field.getName());
             }
+
+            field.setAccessible(true);
+            Object value = field.get(this);
+            YamlComment comment = field.getAnnotation(YamlComment.class);
+
+            nestedMap.put(keyOf(field, field.getAnnotation(YamlKey.class), naming), comment == null ? null : comment.value(), value);
         }
 
         // Convert the nested map to YAML using YamlWriter

--- a/src/main/java/org/avarion/yaml/YamlFileInterface.java
+++ b/src/main/java/org/avarion/yaml/YamlFileInterface.java
@@ -43,6 +43,36 @@ public abstract class YamlFileInterface {
      * }</pre>
      */
     public <T extends YamlFileInterface> T load(final @NotNull File file) throws IOException {
+        return load(file, Set.of());
+    }
+
+    /**
+     * Loads {@code file}, except for the keys named in {@code ignoredKeys}.
+     *
+     * <p>An ignored key is not read: the field keeps whatever it already holds, which for a
+     * freshly built configuration object is its compile-time default. The file is not altered by
+     * this — a following {@link #save(File)} writes the default out, because that is what the
+     * field now says.
+     *
+     * <p>What it is for is the one thing a file-beats-default rule cannot express. A settings
+     * file beats the default for every key it has, which is exactly what an operator's choice
+     * should do, and is also why a default that improves between releases never reaches anybody
+     * whose file already mentions it. Deciding whether a given line is a choice or an untouched
+     * copy of an older default needs to know what that older default was, which is the caller's
+     * business, not this library's. Acting on the answer is this method.
+     *
+     * <p>Names a key the way its field declares it — see {@link #declaredKeys()} — and takes
+     * everything under it: half a block read from the file and half from the defaults is a shape
+     * nobody asked for. Ignoring a key the file does not have does nothing.
+     *
+     * <p>Applied after {@link YamlRename} and {@link YamlKey#previously()} have moved what they
+     * move, so an ignored key stays ignored whether the value in it came from the file directly
+     * or was carried there by a declared move.
+     *
+     * @param ignoredKeys keys the file must not supply; empty for an ordinary load
+     */
+    public <T extends YamlFileInterface> T load(final @NotNull File file, final @NotNull Set<String> ignoredKeys)
+            throws IOException {
         renames = Map.of();
 
         if (!file.exists()) {
@@ -67,6 +97,7 @@ public abstract class YamlFileInterface {
         // lives now and written back there — a migration rather than a value quietly lost to the
         // write-back.
         renames = KeyRenames.applyTo(data, clazz, naming);
+        KeyRenames.drop(data, ignoredKeys);
 
         try {
             loadFields(data, isLenientByDefault, naming);
@@ -74,6 +105,30 @@ public abstract class YamlFileInterface {
             throw new IOException(e);
         }
         return (T) this;
+    }
+
+    /**
+     * The YAML keys this class's fields claim, in the order the fields declare them.
+     *
+     * <p>The unit a caller has to work in when it wants to say something about one setting — an
+     * ignore, a comparison against an older default — because a field is what actually reads the
+     * file. A field may own a whole block, in which case one entry here stands for every leaf
+     * under it.
+     *
+     * @see #load(File, Set)
+     */
+    public @NotNull List<String> declaredKeys() {
+        Naming naming = namingOf(this.getClass().getAnnotation(YamlFile.class));
+        List<String> keys = new ArrayList<>();
+        for (Class<?> clazz = this.getClass(); clazz != null; clazz = clazz.getSuperclass()) {
+            for (Field field : clazz.getDeclaredFields()) {
+                YamlKey annotation = field.getAnnotation(YamlKey.class);
+                if (annotation != null) {
+                    keys.add(keyOf(field, annotation, naming));
+                }
+            }
+        }
+        return keys;
     }
 
     /**

--- a/src/main/java/org/avarion/yaml/YamlFileInterface.java
+++ b/src/main/java/org/avarion/yaml/YamlFileInterface.java
@@ -24,6 +24,9 @@ public abstract class YamlFileInterface {
     static final Object UNKNOWN = new Object();
     private static final YamlWrapper yaml = YamlWrapperFactory.create();
 
+    /** Old key → the key now holding its value, for the last load. Never null. */
+    private @NotNull Map<String, String> renames = Map.of();
+
     // ==================== Load Methods ====================
 
     /**
@@ -40,6 +43,8 @@ public abstract class YamlFileInterface {
      * }</pre>
      */
     public <T extends YamlFileInterface> T load(final @NotNull File file) throws IOException {
+        renames = Map.of();
+
         if (!file.exists()) {
             save(file);
             return (T) this;
@@ -50,18 +55,41 @@ public abstract class YamlFileInterface {
             content = new String(inputStream.readAllBytes());
         }
 
-        Map<String, Object> data = (Map<String, Object>) yaml.load(content);
+        Map<String, Object> parsed = (Map<String, Object>) yaml.load(content);
+        Map<String, Object> data = parsed == null ? new LinkedHashMap<>() : parsed;
 
         Class<?> clazz = this.getClass();
         YamlFile yamlFileAnnotation = clazz.getAnnotation(YamlFile.class);
         boolean isLenientByDefault = yamlFileAnnotation == null || yamlFileAnnotation.lenient() != Leniency.STRICT;
+        Naming naming = namingOf(yamlFileAnnotation);
+
+        // Before any field looks at the file, so a setting that has moved is read from where it
+        // lives now and written back there — a migration rather than a value quietly lost to the
+        // write-back.
+        renames = KeyRenames.applyTo(data, clazz, naming);
 
         try {
-            loadFields(data, isLenientByDefault, namingOf(yamlFileAnnotation));
+            loadFields(data, isLenientByDefault, naming);
         } catch (IllegalAccessException | IllegalArgumentException | NullPointerException | FinalAttribute e) {
             throw new IOException(e);
         }
         return (T) this;
+    }
+
+    /**
+     * What the last load did with keys that have moved: each old path this class declares, mapped
+     * to the key that now holds its value.
+     *
+     * <p>Empty before any load, and after one that found nothing to move. A path appears here
+     * whether its value was carried across or the new key was already set and won — either way
+     * the old key was accounted for by a declaration, which is what tells a caller not to report
+     * it as a setting that vanished without explanation.
+     *
+     * @see YamlKey#previously()
+     * @see YamlRename
+     */
+    public @NotNull Map<String, String> renamesApplied() {
+        return renames;
     }
 
     /**
@@ -218,12 +246,8 @@ public abstract class YamlFileInterface {
 
     // ==================== Field Processing ====================
 
-    private void loadFields(Map<String, Object> data, boolean isLenientByDefault, @NotNull Naming naming)
+    private void loadFields(@NotNull Map<String, Object> data, boolean isLenientByDefault, @NotNull Naming naming)
             throws FinalAttribute, IllegalAccessException, IOException {
-        if (data == null) {
-            data = new HashMap<>();
-        }
-
         for (Class<?> clazz = this.getClass(); clazz != null; clazz = clazz.getSuperclass()) {
             for (Field field : clazz.getDeclaredFields()) {
                 YamlKey keyAnnotation = field.getAnnotation(YamlKey.class);
@@ -277,7 +301,7 @@ public abstract class YamlFileInterface {
             @Nullable Object current)
             throws IOException {
         try {
-            return new TypeConverter(naming, isLenient).getConvertedValue(field, value, current);
+            return new TypeConverter(naming, isLenient).getConvertedValue(field, field.getType(), value, current);
         }
         catch (IOException e) {
             throw new IOException(key + ": " + e.getMessage(), e);
@@ -327,7 +351,7 @@ public abstract class YamlFileInterface {
      * The YAML key for a field: its {@link YamlKey} when one is spelled out, otherwise the
      * field's own name run through the naming strategy.
      */
-    private static @NotNull String keyOf(final @NotNull Field field, final @NotNull YamlKey annotation, final @NotNull Naming naming) {
+    static @NotNull String keyOf(final @NotNull Field field, final @NotNull YamlKey annotation, final @NotNull Naming naming) {
         String key = annotation.value().trim();
         return key.isEmpty() ? naming.convert(field.getName()) : key;
     }

--- a/src/main/java/org/avarion/yaml/YamlFileInterface.java
+++ b/src/main/java/org/avarion/yaml/YamlFileInterface.java
@@ -377,22 +377,27 @@ public abstract class YamlFileInterface {
             result.append("\n");
         }
 
-        // Fields
+        // Fields, up the class hierarchy exactly as loadFields walks it. Reading further than
+        // writing is worse than either alone: an inherited key would be loaded from the file and
+        // then left out of what replaces it, so a load-then-save cycle deletes the setting along
+        // with whatever the operator had put in it.
         Naming naming = namingOf(yamlFileAnnotation);
         NestedMap nestedMap = new NestedMap();
-        for (Field field : clazz.getDeclaredFields()) {
-            YamlKey keyAnnotation = field.getAnnotation(YamlKey.class);
+        for (Class<?> owner = clazz; owner != null; owner = owner.getSuperclass()) {
+            for (Field field : owner.getDeclaredFields()) {
+                YamlKey keyAnnotation = field.getAnnotation(YamlKey.class);
 
-            if (keyAnnotation != null) {
-                if (Modifier.isFinal(field.getModifiers())) {
-                    throw new FinalAttribute(field.getName());
+                if (keyAnnotation != null) {
+                    if (Modifier.isFinal(field.getModifiers())) {
+                        throw new FinalAttribute(field.getName());
+                    }
+
+                    field.setAccessible(true);
+                    Object value = field.get(this);
+                    YamlComment comment = field.getAnnotation(YamlComment.class);
+
+                    nestedMap.put(keyOf(field, keyAnnotation, naming), comment == null ? null : comment.value(), value);
                 }
-
-                field.setAccessible(true);
-                Object value = field.get(this);
-                YamlComment comment = field.getAnnotation(YamlComment.class);
-
-                nestedMap.put(keyOf(field, keyAnnotation, naming), comment == null ? null : comment.value(), value);
             }
         }
 

--- a/src/main/java/org/avarion/yaml/YamlKey.java
+++ b/src/main/java/org/avarion/yaml/YamlKey.java
@@ -29,4 +29,30 @@ import java.lang.annotation.Target;
 public @interface YamlKey {
 	String value() default "";
     Leniency lenient() default Leniency.UNDEFINED;
+
+    /**
+     * Keys this setting used to be spelled as, newest first.
+     *
+     * <p>A key that moves between releases is not merely unread. The file is written back from
+     * the fields, so the old key is dropped and the value under it goes with it. Naming the old
+     * spelling here turns that into a migration: before any field is read, the value is moved to
+     * {@link #value()}, and the write-back persists it there — so the declaration can be deleted
+     * a release or two later, once the files in the wild have been through it.
+     *
+     * <pre>{@code
+     * @YamlKey(value = "storm.damage-per-second", previously = "zone.damage-per-second")
+     * public double damage = 1.0;
+     * }</pre>
+     *
+     * <p>The current key wins when the file holds both, and the older names are tried in the
+     * order given, so list the most recent first. Each entry is a full path from the root of the
+     * file, in the same dot notation as {@link #value()}.
+     *
+     * <p>This moves one key. A whole block that moved — where the old key's new home is inside a
+     * structure no single field owns — is declared on the class with {@link YamlRename}.
+     *
+     * <p>Not read on a record component: a component's key lives inside its record's block, and
+     * moving into or out of that block is a change to the block, which is {@link YamlRename}.
+     */
+    String[] previously() default {};
 }

--- a/src/main/java/org/avarion/yaml/YamlRename.java
+++ b/src/main/java/org/avarion/yaml/YamlRename.java
@@ -1,0 +1,60 @@
+package org.avarion.yaml;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A block of settings that moved, declared on the class it moved within.
+ *
+ * <p>The file is written back from the fields, so a key no field claims is dropped and the
+ * operator's value goes with it. {@link YamlKey#previously()} covers a single setting that
+ * changed name. This covers the case it cannot reach: a whole block whose new home is inside a
+ * structure that no one field owns.
+ *
+ * <pre>{@code
+ * @YamlFile
+ * @YamlRename(from = "mysql", to = "database.mysql")
+ * public class Settings extends YamlFileInterface {
+ *     @YamlKey("database")
+ *     public DatabaseSettings database = DatabaseSettings.mysql("avarion");
+ * }
+ * }</pre>
+ *
+ * <p>There, the credentials that used to be a top-level {@code mysql:} block are now the
+ * {@code mysql} component of a record, beside an {@code engine} the old file never had. No
+ * {@code previously} on any field reaches that: the field is {@code database}, and only part of
+ * it moved. Naming the block does.
+ *
+ * <p>Repeatable, so a class can declare as many moves as its history needs.
+ *
+ * <h2>What it does</h2>
+ * Before any field reads the file, {@code from} and everything under it is moved to {@code to}.
+ * Whatever the block does not fill in is left to the defaults, so the record above comes out
+ * with the operator's credentials and this release's engine. The write-back then persists the
+ * whole thing at the new path, which is what makes the declaration deletable later.
+ *
+ * <p>Nothing happens when {@code from} is absent. When both {@code from} and {@code to} are
+ * present the file has been through a hand-edit, and {@code to} — the key this release
+ * documents — wins, out loud.
+ *
+ * <h2>Order</h2>
+ * Class-level moves run before {@link YamlKey#previously()}, coarse before fine, so a field can
+ * name an old key that only exists once a block has landed. Within one class they run in
+ * declaration order, and a base class's are applied before its subclass's.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Repeatable(YamlRenames.class)
+public @interface YamlRename {
+
+    /** The path the block used to sit at, from the root of the file, dot-separated. */
+    @NotNull String from();
+
+    /** Where it sits now, in the same notation. */
+    @NotNull String to();
+}

--- a/src/main/java/org/avarion/yaml/YamlRenames.java
+++ b/src/main/java/org/avarion/yaml/YamlRenames.java
@@ -1,0 +1,20 @@
+package org.avarion.yaml;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Holds the {@link YamlRename} declarations of one class.
+ *
+ * <p>The container Java needs to let {@code @YamlRename} repeat. Write {@code @YamlRename}
+ * as many times as the class needs and never name this.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface YamlRenames {
+    @NotNull YamlRename[] value();
+}

--- a/src/test/java/org/avarion/yaml/CoverageBoostTests.java
+++ b/src/test/java/org/avarion/yaml/CoverageBoostTests.java
@@ -17,11 +17,11 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class CoverageBoostTests extends TestCommon {
 
-    // ==================== YamlFileInterface: loadFields with null data ====================
+    // ==================== YamlFileInterface: a file that parses to nothing ====================
 
     @Test
     void testLoadEmptyYamlFile() throws IOException {
-        // Write an empty file, then load → data will be null, triggers null check
+        // An empty file parses to null; load() treats that as an empty map, so defaults stand
         try (FileWriter writer = new FileWriter(target)) {
             writer.write("");
         }
@@ -37,7 +37,7 @@ class CoverageBoostTests extends TestCommon {
 
     @Test
     void testLoadYamlWithOnlyComments() throws IOException {
-        // YAML file with only comments → parses to null data
+        // A file holding only comments parses to null just like an empty one
         try (FileWriter writer = new FileWriter(target)) {
             writer.write("# This is just a comment\n# Nothing here\n");
         }

--- a/src/test/java/org/avarion/yaml/IgnoredKeyTests.java
+++ b/src/test/java/org/avarion/yaml/IgnoredKeyTests.java
@@ -1,0 +1,124 @@
+package org.avarion.yaml;
+
+import org.avarion.yaml.testClasses.MovedSubtreeClass;
+import org.avarion.yaml.testClasses.RenamedKeyClass;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Keys the caller has already decided the file must not supply.
+ *
+ * <p>A settings file beats the compile-time default for every key it has, which
+ * is what an operator's choice is supposed to do — and is also why a default
+ * that improves between releases never reaches anybody. Deciding whether a
+ * given line is a choice or an untouched copy of last release's default is the
+ * caller's problem, not this library's; acting on the answer is this method.
+ *
+ * <p>Naming a key here does not delete it from the file. It says the field is
+ * to keep what it already holds, which for a settings class is the default this
+ * release ships.
+ */
+class IgnoredKeyTests extends TestCommon {
+
+    @Test
+    void anIgnoredKeyLeavesItsFieldAtTheValueItAlreadyHeld() throws IOException {
+        writeYaml("""
+                storm:
+                  damage-per-second: 6.0
+                game:
+                  hub-world: lobby
+                """);
+
+        RenamedKeyClass loaded = new RenamedKeyClass().load(target, Set.of("storm.damage-per-second"));
+
+        assertThat(loaded.damage).isEqualTo(1.0);
+        assertThat(loaded.hubWorld).as("everything else is read as usual").isEqualTo("lobby");
+    }
+
+    @Test
+    void andTheWriteBackThenPersistsThatValue() throws IOException {
+        writeYaml("storm:\n  damage-per-second: 6.0\n");
+
+        new RenamedKeyClass().load(target, Set.of("storm.damage-per-second")).save(target);
+
+        assertThat(readFile()).contains("damage-per-second: 1.0");
+    }
+
+    @Test
+    void ignoringAKeyTheFileDoesNotHaveChangesNothing() throws IOException {
+        writeYaml("game:\n  hub-world: lobby\n");
+
+        RenamedKeyClass loaded = new RenamedKeyClass().load(target, Set.of("storm.damage-per-second"));
+
+        assertThat(loaded.hubWorld).isEqualTo("lobby");
+        assertThat(loaded.damage).isEqualTo(1.0);
+    }
+
+    @Test
+    void ignoringABlockTakesEverythingUnderItWithIt() throws IOException {
+        // The unit an ignore is worth expressing in is a field, and a field may
+        // own a whole block. Half a block read from the file and half from the
+        // defaults is a shape nobody asked for.
+        writeYaml("""
+                database:
+                  engine: H2
+                  mysql:
+                    hostname: theirs
+                    port: 9999
+                    password: theirs
+                """);
+
+        MovedSubtreeClass loaded = new MovedSubtreeClass().load(target, Set.of("database"));
+
+        assertThat(loaded.database.engine()).isEqualTo(MovedSubtreeClass.Engine.MYSQL);
+        assertThat(loaded.database.mysql().hostname()).isEqualTo("db.default");
+        assertThat(loaded.database.mysql().port()).isEqualTo(3306);
+    }
+
+    @Test
+    void anIgnoreIsAppliedAfterAMoveHasHappened() throws IOException {
+        // Otherwise a declared move would put a value back into a key the
+        // caller has just decided must not come from the file.
+        writeYaml("""
+                mysql:
+                  hostname: theirs
+                  port: 9999
+                  password: theirs
+                """);
+
+        MovedSubtreeClass loaded = new MovedSubtreeClass().load(target, Set.of("database.mysql"));
+
+        assertThat(loaded.database.mysql().hostname())
+                .as("the move landed there and the ignore then took it away again")
+                .isEqualTo("db.default");
+    }
+
+    @Test
+    void ignoringNothingIsAnOrdinaryLoad() throws IOException {
+        writeYaml("storm:\n  damage-per-second: 6.0\n");
+
+        RenamedKeyClass loaded = new RenamedKeyClass().load(target, Set.of());
+
+        assertThat(loaded.damage).isEqualTo(6.0);
+    }
+
+    // ===== declaredKeys =====
+
+    @Test
+    void aClassCanSayWhichKeysItsFieldsClaim() throws IOException {
+        // The caller deciding what to ignore has to work in the same units the
+        // fields do, and only the class knows what those are.
+        assertThat(new RenamedKeyClass().declaredKeys())
+                .containsExactly("storm.damage-per-second", "hud.boss-bar.colour", "game.hub-world");
+    }
+
+    @Test
+    void aKeyDerivedFromItsFieldNameIsInThereTheWayItIsWritten() throws IOException {
+        assertThat(new org.avarion.yaml.testClasses.BareKeyClass().declaredKeys())
+                .containsExactly("server_name", "max_players", "debug");
+    }
+}

--- a/src/test/java/org/avarion/yaml/IgnoredKeyTests.java
+++ b/src/test/java/org/avarion/yaml/IgnoredKeyTests.java
@@ -109,7 +109,7 @@ class IgnoredKeyTests extends TestCommon {
     // ===== declaredKeys =====
 
     @Test
-    void aClassCanSayWhichKeysItsFieldsClaim() throws IOException {
+    void aClassCanSayWhichKeysItsFieldsClaim() {
         // The caller deciding what to ignore has to work in the same units the
         // fields do, and only the class knows what those are.
         assertThat(new RenamedKeyClass().declaredKeys())
@@ -117,7 +117,7 @@ class IgnoredKeyTests extends TestCommon {
     }
 
     @Test
-    void aKeyDerivedFromItsFieldNameIsInThereTheWayItIsWritten() throws IOException {
+    void aKeyDerivedFromItsFieldNameIsInThereTheWayItIsWritten() {
         assertThat(new org.avarion.yaml.testClasses.BareKeyClass().declaredKeys())
                 .containsExactly("server_name", "max_players", "debug");
     }

--- a/src/test/java/org/avarion/yaml/InheritedFieldTests.java
+++ b/src/test/java/org/avarion/yaml/InheritedFieldTests.java
@@ -1,0 +1,59 @@
+package org.avarion.yaml;
+
+import org.avarion.yaml.testClasses.InheritedFieldClass;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A field a settings class inherits is a setting like any other.
+ *
+ * <p>Reading already walked the class hierarchy while writing looked only at the class itself,
+ * and the two disagreeing is worse than either alone: an inherited key loaded from the file and
+ * then left out of everything written back means a load-then-save cycle deletes it, along with
+ * whatever the operator had put there.
+ */
+class InheritedFieldTests extends TestCommon {
+
+    @Test
+    void anInheritedFieldIsWrittenOutLikeAnyOther() throws IOException {
+        new InheritedFieldClass.Derived().save(target);
+
+        assertThat(readFile())
+                .contains("debug: false")
+                .contains("timeout: 30")
+                .as("its comment comes with it").contains("Belongs to every configuration");
+    }
+
+    @Test
+    void anInheritedFieldIsReadFromTheFile() throws IOException {
+        writeYaml("""
+                shared:
+                  debug: true
+                own:
+                  timeout: 90
+                """);
+
+        InheritedFieldClass.Derived loaded = new InheritedFieldClass.Derived().load(target);
+
+        assertThat(loaded.debug).isTrue();
+        assertThat(loaded.timeout).isEqualTo(90);
+    }
+
+    @Test
+    void andSurvivesTheRoundTripThatUsedToDropIt() throws IOException {
+        writeYaml("shared:\n  debug: true\nown:\n  timeout: 90\n");
+
+        new InheritedFieldClass.Derived().load(target).save(target);
+
+        assertThat(readFile()).contains("debug: true").contains("timeout: 90");
+    }
+
+    @Test
+    void andItIsOneOfTheKeysTheClassSaysItClaims() throws IOException {
+        assertThat(new InheritedFieldClass.Derived().declaredKeys())
+                .containsExactlyInAnyOrder("own.timeout", "shared.debug");
+    }
+}

--- a/src/test/java/org/avarion/yaml/InheritedFieldTests.java
+++ b/src/test/java/org/avarion/yaml/InheritedFieldTests.java
@@ -52,7 +52,7 @@ class InheritedFieldTests extends TestCommon {
     }
 
     @Test
-    void andItIsOneOfTheKeysTheClassSaysItClaims() throws IOException {
+    void andItIsOneOfTheKeysTheClassSaysItClaims() {
         assertThat(new InheritedFieldClass.Derived().declaredKeys())
                 .containsExactlyInAnyOrder("own.timeout", "shared.debug");
     }

--- a/src/test/java/org/avarion/yaml/NamingTests.java
+++ b/src/test/java/org/avarion/yaml/NamingTests.java
@@ -107,20 +107,23 @@ class NamingTests extends TestCommon {
     @Test
     void testKeepDoesNotAnswerToConvertedComponentKeys() throws IOException {
         // The block itself is found, but its components are spelled the SNAKE_CASE way.
+        // The two keys that DO line up are given values unlike the defaults, so a component
+        // that kept its default cannot be mistaken for one that was read.
         writeYaml("""
                 derivedBlock:
                   model_id: a
                   model_id2: b
                   http_url: c
-                  name: d
-                  someCamelKey: e
+                  name: from-file
+                  someCamelKey: also-from-file
                 """);
 
         KeepNamingClass loaded = new KeepNamingClass();
         loaded.load(target);
 
         // Under KEEP only 'name' (single word, so unaffected by conversion) and the explicitly
-        // named key still line up; the converted spellings are not recognised.
-        assertEquals(new NamingRecord(null, null, null, "d", "e"), loaded.derivedBlock);
+        // named key still line up. The converted spellings are not recognised, so nothing in the
+        // file addresses those three components and they keep the defaults they came with.
+        assertEquals(new NamingRecord("a", "b", "c", "from-file", "also-from-file"), loaded.derivedBlock);
     }
 }

--- a/src/test/java/org/avarion/yaml/PartialRecordTests.java
+++ b/src/test/java/org/avarion/yaml/PartialRecordTests.java
@@ -1,5 +1,6 @@
 package org.avarion.yaml;
 
+import org.avarion.yaml.testClasses.PackagePrivateRecordClass;
 import org.avarion.yaml.testClasses.PartialRecordClass;
 import org.avarion.yaml.testClasses.PartialRecordClass.Engine;
 import org.junit.jupiter.api.Test;
@@ -155,5 +156,22 @@ class PartialRecordTests extends TestCommon {
                 .contains("hostname: moved-host")
                 .contains("port: 3306")
                 .contains("password: secret");
+    }
+
+    @Test
+    void aRecordThePluginKeepsToItsOwnPackageStillKeepsItsDefaults() throws IOException {
+        // The record's canonical constructor and accessors are reachable only by opening them
+        // reflectively; the fallback for an omitted component has to survive that.
+        writeYaml("""
+                credentials:
+                  hostname: from-file
+                """);
+
+        PackagePrivateRecordClass loaded = new PackagePrivateRecordClass().load(target);
+
+        assertThat(loaded.hostname()).isEqualTo("from-file");
+        assertThat(loaded.port())
+                .as("the default for the omitted component came through the opened accessor")
+                .isEqualTo(3306);
     }
 }

--- a/src/test/java/org/avarion/yaml/PartialRecordTests.java
+++ b/src/test/java/org/avarion/yaml/PartialRecordTests.java
@@ -1,0 +1,124 @@
+package org.avarion.yaml;
+
+import org.avarion.yaml.testClasses.PartialRecordClass;
+import org.avarion.yaml.testClasses.PartialRecordClass.Engine;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * A record component the file does not set keeps its default.
+ *
+ * <p>That is already how a plain field behaves — a key the file omits leaves
+ * the field alone — and there is no reason for the rule to stop at a record's
+ * edge. A block the file mentions at all used to be taken whole: every
+ * component the file did not name came out {@code null}, or, when the component
+ * was a primitive, refused to load. So a file naming one setting inside a block
+ * silently lost the rest of it.
+ *
+ * <p>A key that IS in the file and IS null still means null, and still refuses
+ * to go into a primitive. Not writing something down and writing down nothing
+ * are different statements, and only the first one is a question about
+ * defaults.
+ */
+class PartialRecordTests extends TestCommon {
+
+    @Test
+    void aComponentTheFileOmitsKeepsItsDefault() throws IOException {
+        writeYaml("""
+                database:
+                  mysql:
+                    hostname: moved-host
+                    port: 1234
+                    password: hunter2
+                """);
+
+        PartialRecordClass loaded = new PartialRecordClass().load(target);
+
+        assertThat(loaded.database.engine())
+                .as("the file never mentions engine, so the shipped default stands")
+                .isEqualTo(Engine.MYSQL);
+        assertThat(loaded.database.mysql().hostname()).isEqualTo("moved-host");
+    }
+
+    @Test
+    void thatHoldsInsideANestedRecordToo() throws IOException {
+        writeYaml("""
+                database:
+                  engine: H2
+                  mysql:
+                    hostname: moved-host
+                """);
+
+        PartialRecordClass loaded = new PartialRecordClass().load(target);
+
+        assertThat(loaded.database.engine()).isEqualTo(Engine.H2);
+        assertThat(loaded.database.mysql().hostname()).isEqualTo("moved-host");
+        assertThat(loaded.database.mysql().port())
+                .as("a primitive component the file omits is the default, not a failure to load")
+                .isEqualTo(3306);
+        assertThat(loaded.database.mysql().password()).isEqualTo("secret");
+    }
+
+    @Test
+    void aBlockTheFileOmitsEntirelyIsStillTheWholeDefault() throws IOException {
+        writeYaml("unrelated: changed\n");
+
+        PartialRecordClass loaded = new PartialRecordClass().load(target);
+
+        assertThat(loaded.unrelated).isEqualTo("changed");
+        assertThat(loaded.database.engine()).isEqualTo(Engine.MYSQL);
+        assertThat(loaded.database.mysql().hostname()).isEqualTo("db.default");
+    }
+
+    @Test
+    void aKeyWrittenDownAsNullIsStillNull() throws IOException {
+        // Writing 'engine:' with nothing after it is a statement, and it is not
+        // the same statement as leaving the line out.
+        writeYaml("""
+                database:
+                  engine:
+                  mysql:
+                    hostname: moved-host
+                """);
+
+        PartialRecordClass loaded = new PartialRecordClass().load(target);
+
+        assertThat(loaded.database.engine()).isNull();
+    }
+
+    @Test
+    void aPrimitiveWrittenDownAsNullStillRefusesToLoad() throws IOException {
+        writeYaml("""
+                database:
+                  mysql:
+                    hostname: moved-host
+                    port:
+                """);
+
+        assertThatThrownBy(() -> new PartialRecordClass().load(target))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("port");
+    }
+
+    @Test
+    void theWriteBackFillsInWhatTheFileLeftOut() throws IOException {
+        writeYaml("""
+                database:
+                  mysql:
+                    hostname: moved-host
+                """);
+
+        new PartialRecordClass().load(target).save(target);
+
+        assertThat(readFile())
+                .as("the defaults that filled the gaps are now written down")
+                .contains("engine: 'MYSQL'")
+                .contains("hostname: moved-host")
+                .contains("port: 3306")
+                .contains("password: secret");
+    }
+}

--- a/src/test/java/org/avarion/yaml/PartialRecordTests.java
+++ b/src/test/java/org/avarion/yaml/PartialRecordTests.java
@@ -105,6 +105,41 @@ class PartialRecordTests extends TestCommon {
     }
 
     @Test
+    void aFallbackThatRefusesToAnswerIsTreatedAsNoAnswer() throws IOException {
+        // A record may write its own accessor, and that accessor may throw. Asking it what the
+        // default was is a convenience, so a refusal costs the convenience and nothing else --
+        // the component takes the road it took before there were fallbacks at all.
+        writeYaml("awkward:\n  other: from-file\n");
+
+        AwkwardHolder loaded = new AwkwardHolder().load(target);
+
+        assertThat(loaded.awkward.other()).isEqualTo("from-file");
+        assertThat(loaded.awkward.temperamental()).isNull();
+    }
+
+    /**
+     * A record whose accessor refuses to answer for one particular value — the one the default
+     * instance is built with, so it is exactly the fallback probe that gets refused.
+     */
+    public record Awkward(String temperamental, String other) {
+        static final String REFUSES = "asking me about this one throws";
+
+        @Override
+        public String temperamental() {
+            if (REFUSES.equals(temperamental)) {
+                throw new IllegalStateException("this accessor does not answer");
+            }
+            return temperamental;
+        }
+    }
+
+    @YamlFile
+    public static class AwkwardHolder extends YamlFileInterface {
+        @YamlKey("awkward")
+        public Awkward awkward = new Awkward(Awkward.REFUSES, "default");
+    }
+
+    @Test
     void theWriteBackFillsInWhatTheFileLeftOut() throws IOException {
         writeYaml("""
                 database:

--- a/src/test/java/org/avarion/yaml/RecordAnnotationTests.java
+++ b/src/test/java/org/avarion/yaml/RecordAnnotationTests.java
@@ -173,8 +173,12 @@ class RecordAnnotationTests extends TestCommon {
         RenamedRecordClass loaded = new RenamedRecordClass();
         loaded.load(target);
 
-        // 'port' still loads by component name; the renamed ones no longer answer to it.
-        assertEquals(new RenamedDatabase(null, 3306, null), loaded.database);
+        // 'port' still loads by component name; the renamed ones no longer answer to it. As far
+        // as those two are concerned the file said nothing about them, so their defaults stand —
+        // the same thing an unrecognised key does at the top level, where it leaves the field
+        // alone and is reported by whoever is watching for keys that belong to nothing.
+        assertEquals(new RenamedDatabase("localhost", 3306, new RenamedCredentials("admin", "secret")),
+                loaded.database);
     }
 
     // ===== Unsupported dotted keys =====

--- a/src/test/java/org/avarion/yaml/RenameTests.java
+++ b/src/test/java/org/avarion/yaml/RenameTests.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.logging.LogRecord;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Declared renames: where a setting used to live, said once in the class.
@@ -153,6 +154,21 @@ class RenameTests extends TestCommon {
         assertThat(loaded.renamesApplied())
                 .containsEntry("zone.damage-per-second", "storm.damage-per-second")
                 .hasSize(1);
+    }
+
+    @Test
+    void theRecordOfMovesIsAReportNotAThingToEdit() throws IOException {
+        // What the load did is not negotiable after the fact, and handing out the live map
+        // would let a caller quietly rewrite it.
+        writeYaml("""
+                zone:
+                  damage-per-second: 6.0
+                """);
+
+        RenamedKeyClass loaded = new RenamedKeyClass().load(target);
+
+        assertThatThrownBy(() -> loaded.renamesApplied().clear())
+                .isInstanceOf(UnsupportedOperationException.class);
     }
 
     @Test

--- a/src/test/java/org/avarion/yaml/RenameTests.java
+++ b/src/test/java/org/avarion/yaml/RenameTests.java
@@ -1,0 +1,368 @@
+package org.avarion.yaml;
+
+import org.avarion.yaml.testClasses.BlockedRenameClass;
+import org.avarion.yaml.testClasses.InheritedRenameClass;
+import org.avarion.yaml.testClasses.MovedSubtreeClass;
+import org.avarion.yaml.testClasses.MovedSubtreeClass.Engine;
+import org.avarion.yaml.testClasses.OddRenameClass;
+import org.avarion.yaml.testClasses.RenamedKeyClass;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.logging.LogRecord;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Declared renames: where a setting used to live, said once in the class.
+ *
+ * <p>Without them a key that moves between releases is not merely unread. The
+ * file is written back from the fields, so the old key is dropped and whatever
+ * was under it goes too — which is how a production database lost its
+ * credentials to a routine upgrade. Declaring the move turns that into a
+ * migration: the value is carried to the new key before any field reads it, and
+ * the write-back then persists it there.
+ */
+class RenameTests extends TestCommon {
+
+    /** Everything the library said during the load. */
+    private List<String> said() {
+        return logs.stream().map(LogRecord::getMessage).toList();
+    }
+
+    // ===== Field-level: @YamlKey(previously = ...) =====
+
+    @Test
+    void aValueUnderTheOldKeyIsReadIntoTheNewOne() throws IOException {
+        writeYaml("""
+                zone:
+                  damage-per-second: 6.0
+                """);
+
+        RenamedKeyClass loaded = new RenamedKeyClass().load(target);
+
+        assertThat(loaded.damage).isEqualTo(6.0);
+    }
+
+    @Test
+    void andTheWriteBackPersistsItUnderTheNewKey() throws IOException {
+        writeYaml("""
+                zone:
+                  damage-per-second: 6.0
+                """);
+
+        new RenamedKeyClass().load(target).save(target);
+
+        assertThat(readFile())
+                .as("a real migration, not a read-through: the next release need not know")
+                .contains("damage-per-second: 6.0")
+                .doesNotContain("zone:");
+    }
+
+    @Test
+    void theMoveIsSaidOutLoud() throws IOException {
+        writeYaml("zone:\n  damage-per-second: 6.0\n");
+
+        new RenamedKeyClass().load(target);
+
+        assertThat(said()).anySatisfy(line ->
+                assertThat(line).contains("zone.damage-per-second").contains("storm.damage-per-second"));
+    }
+
+    @Test
+    void anyOfSeveralOldNamesIsAccepted() throws IOException {
+        writeYaml("bar:\n  colour: BLUE\n");
+
+        RenamedKeyClass loaded = new RenamedKeyClass().load(target);
+
+        assertThat(loaded.colour).isEqualTo("BLUE");
+    }
+
+    @Test
+    void theOldestNameLosesToANewerOne() throws IOException {
+        // Two moves in the field's history and a file stuck at the older one is
+        // one thing; a file holding both is a file that was hand-edited across
+        // an upgrade, and the later spelling is the better guess at intent.
+        writeYaml("""
+                zone:
+                  bar:
+                    colour: GREEN
+                bar:
+                  colour: BLUE
+                """);
+
+        RenamedKeyClass loaded = new RenamedKeyClass().load(target);
+
+        assertThat(loaded.colour).isEqualTo("GREEN");
+    }
+
+    @Test
+    void theCurrentKeyBeatsAnOldOneThatIsAlsoStillThere() throws IOException {
+        writeYaml("""
+                storm:
+                  damage-per-second: 2.0
+                zone:
+                  damage-per-second: 6.0
+                """);
+
+        RenamedKeyClass loaded = new RenamedKeyClass().load(target);
+
+        assertThat(loaded.damage)
+                .as("the key this release actually documents is the one they meant")
+                .isEqualTo(2.0);
+    }
+
+    @Test
+    void andThatIsSaidOutLoudToo() throws IOException {
+        writeYaml("storm:\n  damage-per-second: 2.0\nzone:\n  damage-per-second: 6.0\n");
+
+        new RenamedKeyClass().load(target);
+
+        assertThat(said()).anySatisfy(line ->
+                assertThat(line).contains("zone.damage-per-second").contains("storm.damage-per-second"));
+    }
+
+    @Test
+    void aFileAlreadyAtTheNewKeyIsSilent() throws IOException {
+        writeYaml("storm:\n  damage-per-second: 2.0\n");
+
+        RenamedKeyClass loaded = new RenamedKeyClass().load(target);
+
+        assertThat(loaded.damage).isEqualTo(2.0);
+        assertThat(said()).isEmpty();
+    }
+
+    @Test
+    void aFileWithNeitherKeyIsSilentAndKeepsTheDefault() throws IOException {
+        writeYaml("game:\n  hub-world: lobby\n");
+
+        RenamedKeyClass loaded = new RenamedKeyClass().load(target);
+
+        assertThat(loaded.damage).isEqualTo(1.0);
+        assertThat(loaded.hubWorld).isEqualTo("lobby");
+        assertThat(said()).isEmpty();
+    }
+
+    @Test
+    void whatMovedIsOnTheRecord() throws IOException {
+        writeYaml("zone:\n  damage-per-second: 6.0\n");
+
+        RenamedKeyClass loaded = new RenamedKeyClass().load(target);
+
+        assertThat(loaded.renamesApplied())
+                .containsEntry("zone.damage-per-second", "storm.damage-per-second")
+                .hasSize(1);
+    }
+
+    @Test
+    void aLoadThatMovedNothingHasAnEmptyRecord() throws IOException {
+        writeYaml("game:\n  hub-world: lobby\n");
+
+        assertThat(new RenamedKeyClass().load(target).renamesApplied()).isEmpty();
+    }
+
+    // ===== Class-level: @YamlRename, for a block that moved =====
+
+    @Test
+    void aWholeBlockCanMoveIntoAKeyThatDidNotExist() throws IOException {
+        // The incident, in miniature: every credential the operator had was
+        // under a top-level mysql block, and the block is now one component of
+        // a record one level down.
+        writeYaml("""
+                mysql:
+                  hostname: db.internal
+                  port: 3307
+                  password: hunter2
+                """);
+
+        MovedSubtreeClass loaded = new MovedSubtreeClass().load(target);
+
+        assertThat(loaded.database.mysql().hostname()).isEqualTo("db.internal");
+        assertThat(loaded.database.mysql().port()).isEqualTo(3307);
+        assertThat(loaded.database.mysql().password()).isEqualTo("hunter2");
+        assertThat(loaded.database.engine())
+                .as("the old file never had an engine, so the block it moved into keeps its default")
+                .isEqualTo(Engine.MYSQL);
+    }
+
+    @Test
+    void andTheUpgradedFileHoldsThemAtTheNewPath() throws IOException {
+        writeYaml("""
+                mysql:
+                  hostname: db.internal
+                  port: 3307
+                  password: hunter2
+                """);
+
+        new MovedSubtreeClass().load(target).save(target);
+
+        String written = readFile();
+        assertThat(written).contains("database:").contains("hostname: db.internal");
+        assertThat(written.indexOf("mysql:"))
+                .as("the only mysql: left is the one nested under database:")
+                .isGreaterThan(written.indexOf("database:"));
+    }
+
+    @Test
+    void theBlockThatMovedIsOnTheRecord() throws IOException {
+        writeYaml("mysql:\n  hostname: db.internal\n  port: 3307\n  password: p\n");
+
+        MovedSubtreeClass loaded = new MovedSubtreeClass().load(target);
+
+        assertThat(loaded.renamesApplied()).containsEntry("mysql", "database.mysql");
+    }
+
+    @Test
+    void aBlockAlreadyAtItsNewHomeWins() throws IOException {
+        writeYaml("""
+                database:
+                  mysql:
+                    hostname: current.host
+                    port: 3306
+                    password: p
+                mysql:
+                  hostname: stale.host
+                  port: 3307
+                  password: q
+                """);
+
+        MovedSubtreeClass loaded = new MovedSubtreeClass().load(target);
+
+        assertThat(loaded.database.mysql().hostname()).isEqualTo("current.host");
+        assertThat(said()).anySatisfy(line -> assertThat(line).contains("mysql").contains("database.mysql"));
+    }
+
+    @Test
+    void aFileWithoutTheOldBlockIsUntouchedAndSilent() throws IOException {
+        writeYaml("""
+                database:
+                  engine: H2
+                """);
+
+        MovedSubtreeClass loaded = new MovedSubtreeClass().load(target);
+
+        assertThat(loaded.database.engine()).isEqualTo(Engine.H2);
+        assertThat(loaded.database.mysql().hostname()).isEqualTo("db.default");
+        assertThat(said()).isEmpty();
+        assertThat(loaded.renamesApplied()).isEmpty();
+    }
+
+    @Test
+    void anEmptyFileIsSilent() throws IOException {
+        writeYaml("");
+
+        MovedSubtreeClass loaded = new MovedSubtreeClass().load(target);
+
+        assertThat(loaded.database.mysql().hostname()).isEqualTo("db.default");
+        assertThat(said()).isEmpty();
+    }
+
+    @Test
+    void aBaseClassCanDeclareAMoveAndItsSubclassAnother() throws IOException {
+        // Coarse to fine, base first: 'old.value' has to become 'middle.value' before the
+        // subclass's declaration has anything to find.
+        writeYaml("old:\n  value: carried\n");
+
+        InheritedRenameClass.Derived loaded = new InheritedRenameClass.Derived().load(target);
+
+        assertThat(loaded.value).isEqualTo("carried");
+        assertThat(loaded.renamesApplied())
+                .containsEntry("old", "middle")
+                .containsEntry("middle.value", "current.value");
+    }
+
+    // ===== Declarations that must do nothing =====
+
+    @Test
+    void aBlankOldNameIsIgnored() throws IOException {
+        writeYaml("kept:\n  blank: from-file\n");
+
+        OddRenameClass loaded = new OddRenameClass().load(target);
+
+        assertThat(loaded.blank).isEqualTo("from-file");
+        assertThat(loaded.renamesApplied()).isEmpty();
+        assertThat(said()).isEmpty();
+    }
+
+    @Test
+    void aKeyDeclaredAsItsOwnFormerSelfIsIgnored() throws IOException {
+        writeYaml("kept:\n  circular: from-file\n");
+
+        OddRenameClass loaded = new OddRenameClass().load(target);
+
+        assertThat(loaded.circular).isEqualTo("from-file");
+        assertThat(loaded.renamesApplied()).isEmpty();
+    }
+
+    @Test
+    void anOldKeyWrittenDownEmptyIsNothingToCarry() throws IOException {
+        // 'old.empty-target:' with nothing after it is not a value, and moving a nothing to the
+        // new key would only replace a real default with it.
+        writeYaml("old:\n  empty-target:\n");
+
+        OddRenameClass loaded = new OddRenameClass().load(target);
+
+        assertThat(loaded.emptyTarget).isEqualTo("default");
+        assertThat(loaded.renamesApplied()).isEmpty();
+        assertThat(said()).isEmpty();
+    }
+
+    @Test
+    void aBlankDestinationIsIgnored() throws IOException {
+        writeYaml("old:\n  nowhere: mine\n");
+
+        OddRenameClass loaded = new OddRenameClass().load(target);
+
+        assertThat(loaded.renamesApplied()).isEmpty();
+        assertThat(said()).isEmpty();
+    }
+
+    @Test
+    void aNewKeyLeftEmptyIsNotAValueToBeBeatenBy() throws IOException {
+        // Clearing the new line out is how somebody empties a setting they do not want, and it
+        // is not the same as having chosen something. The old value still has somewhere to go.
+        writeYaml("""
+                storm:
+                  damage-per-second:
+                zone:
+                  damage-per-second: 6.0
+                """);
+
+        RenamedKeyClass loaded = new RenamedKeyClass().load(target);
+
+        assertThat(loaded.damage).isEqualTo(6.0);
+    }
+
+    @Test
+    void anOldKeyBehindAValueRatherThanABlockIsNotFound() throws IOException {
+        // 'old' is a setting in this file, so 'old.empty-target' names nothing.
+        writeYaml("old: just-a-string\nkept:\n  empty-target: mine\n");
+
+        OddRenameClass loaded = new OddRenameClass().load(target);
+
+        assertThat(loaded.emptyTarget).isEqualTo("mine");
+        assertThat(loaded.renamesApplied()).isEmpty();
+    }
+
+    @Test
+    void aMoveIntoAPathBlockedByAValueIsRefusedRatherThanForced() throws IOException {
+        // 'wing' is a setting in this file, so there is nowhere to build 'wing.nested'.
+        // Overwriting it would destroy one of their settings to rescue another.
+        writeYaml("""
+                wing: solid
+                loose: mine
+                """);
+
+        BlockedRenameClass loaded = new BlockedRenameClass().load(target);
+
+        assertThat(loaded.value)
+                .as("nothing was carried, so the field is left at its default")
+                .isEqualTo("default");
+        assertThat(loaded.renamesApplied())
+                .as("and the old key is not claimed as handled, so it can still be reported")
+                .isEmpty();
+        assertThat(said()).anySatisfy(line ->
+                assertThat(line).contains("loose").contains("cannot be created"));
+    }
+}

--- a/src/test/java/org/avarion/yaml/RenameTests.java
+++ b/src/test/java/org/avarion/yaml/RenameTests.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.LogRecord;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -165,10 +166,9 @@ class RenameTests extends TestCommon {
                   damage-per-second: 6.0
                 """);
 
-        RenamedKeyClass loaded = new RenamedKeyClass().load(target);
+        Map<String, String> applied = new RenamedKeyClass().load(target).renamesApplied();
 
-        assertThatThrownBy(() -> loaded.renamesApplied().clear())
-                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(applied::clear).isInstanceOf(UnsupportedOperationException.class);
     }
 
     @Test

--- a/src/test/java/org/avarion/yaml/testClasses/BlockedRenameClass.java
+++ b/src/test/java/org/avarion/yaml/testClasses/BlockedRenameClass.java
@@ -1,0 +1,18 @@
+package org.avarion.yaml.testClasses;
+
+import org.avarion.yaml.YamlFile;
+import org.avarion.yaml.YamlFileInterface;
+import org.avarion.yaml.YamlKey;
+import org.avarion.yaml.YamlRename;
+
+/**
+ * A move whose destination sits under a path an operator may well have used for something else.
+ * If {@code wing} is a setting in their file, there is nowhere to build {@code wing.nested}.
+ */
+@YamlFile
+@YamlRename(from = "loose", to = "wing.nested.value")
+public class BlockedRenameClass extends YamlFileInterface {
+
+    @YamlKey("wing.nested.value")
+    public String value = "default";
+}

--- a/src/test/java/org/avarion/yaml/testClasses/InheritedFieldClass.java
+++ b/src/test/java/org/avarion/yaml/testClasses/InheritedFieldClass.java
@@ -1,0 +1,27 @@
+package org.avarion.yaml.testClasses;
+
+import org.avarion.yaml.YamlComment;
+import org.avarion.yaml.YamlFile;
+import org.avarion.yaml.YamlFileInterface;
+import org.avarion.yaml.YamlKey;
+
+/**
+ * A settings class with a base class holding settings of its own — the shape a framework takes
+ * when it has something every configuration needs to carry.
+ */
+public class InheritedFieldClass {
+
+    @YamlFile(header = "Inherited fields")
+    public abstract static class Base extends YamlFileInterface {
+
+        @YamlComment("Belongs to every configuration, not to any one of them")
+        @YamlKey("shared.debug")
+        public boolean debug = false;
+    }
+
+    public static class Derived extends Base {
+
+        @YamlKey("own.timeout")
+        public int timeout = 30;
+    }
+}

--- a/src/test/java/org/avarion/yaml/testClasses/InheritedRenameClass.java
+++ b/src/test/java/org/avarion/yaml/testClasses/InheritedRenameClass.java
@@ -1,0 +1,25 @@
+package org.avarion.yaml.testClasses;
+
+import org.avarion.yaml.YamlFile;
+import org.avarion.yaml.YamlFileInterface;
+import org.avarion.yaml.YamlKey;
+import org.avarion.yaml.YamlRename;
+
+/**
+ * A move declared on a base class, and another on the class that extends it — the base's is
+ * applied first, so the subclass can name a path the base has just created.
+ */
+@YamlFile
+public class InheritedRenameClass {
+
+    @YamlRename(from = "old", to = "middle")
+    public abstract static class Base extends YamlFileInterface {
+    }
+
+    @YamlRename(from = "middle.value", to = "current.value")
+    public static class Derived extends Base {
+
+        @YamlKey("current.value")
+        public String value = "default";
+    }
+}

--- a/src/test/java/org/avarion/yaml/testClasses/MovedSubtreeClass.java
+++ b/src/test/java/org/avarion/yaml/testClasses/MovedSubtreeClass.java
@@ -1,0 +1,31 @@
+package org.avarion.yaml.testClasses;
+
+import org.avarion.yaml.YamlFile;
+import org.avarion.yaml.YamlFileInterface;
+import org.avarion.yaml.YamlKey;
+import org.avarion.yaml.YamlRename;
+
+/**
+ * The shape that no field-level alias can express: a whole block that moved one
+ * level down, into a component of a record that did not exist before.
+ *
+ * <p>The old file had a top-level {@code mysql:} block. The block is now the
+ * {@code mysql} component inside {@code database}, beside an {@code engine} the
+ * old file never had — so the move has to be declared against the block, not
+ * against any one field.
+ */
+@YamlFile
+@YamlRename(from = "mysql", to = "database.mysql")
+public class MovedSubtreeClass extends YamlFileInterface {
+
+    public enum Engine {MYSQL, H2}
+
+    public record Credentials(String hostname, int port, String password) {
+    }
+
+    public record Database(Engine engine, Credentials mysql) {
+    }
+
+    @YamlKey("database")
+    public Database database = new Database(Engine.MYSQL, new Credentials("db.default", 3306, "secret"));
+}

--- a/src/test/java/org/avarion/yaml/testClasses/OddRenameClass.java
+++ b/src/test/java/org/avarion/yaml/testClasses/OddRenameClass.java
@@ -1,0 +1,25 @@
+package org.avarion.yaml.testClasses;
+
+import org.avarion.yaml.YamlFile;
+import org.avarion.yaml.YamlFileInterface;
+import org.avarion.yaml.YamlKey;
+import org.avarion.yaml.YamlRename;
+
+/**
+ * Declarations that say nothing: a blank old name, a blank destination, and one that names the
+ * key the field already uses. All three are what a half-finished edit looks like, and none of
+ * them may do anything.
+ */
+@YamlFile
+@YamlRename(from = "old.nowhere", to = "   ")
+public class OddRenameClass extends YamlFileInterface {
+
+    @YamlKey(value = "kept.blank", previously = {"", "   "})
+    public String blank = "default";
+
+    @YamlKey(value = "kept.circular", previously = "kept.circular")
+    public String circular = "default";
+
+    @YamlKey(value = "kept.empty-target", previously = "old.empty-target")
+    public String emptyTarget = "default";
+}

--- a/src/test/java/org/avarion/yaml/testClasses/PackagePrivateRecordClass.java
+++ b/src/test/java/org/avarion/yaml/testClasses/PackagePrivateRecordClass.java
@@ -1,0 +1,30 @@
+package org.avarion.yaml.testClasses;
+
+import org.avarion.yaml.YamlFile;
+import org.avarion.yaml.YamlFileInterface;
+import org.avarion.yaml.YamlKey;
+
+/**
+ * A settings class whose record is package-private — the shape a plugin takes when it keeps a
+ * credentials type to itself. The library can reach the record's canonical constructor and its
+ * accessors only by opening them reflectively, so this class is what keeps those
+ * {@code setAccessible} calls honest: without them, a partial load of this record cannot consult
+ * the defaults it is supposed to keep.
+ */
+@YamlFile
+public class PackagePrivateRecordClass extends YamlFileInterface {
+
+    record Credentials(String hostname, int port) {
+    }
+
+    @YamlKey("credentials")
+    Credentials credentials = new Credentials("db.default", 3306);
+
+    public String hostname() {
+        return credentials.hostname();
+    }
+
+    public int port() {
+        return credentials.port();
+    }
+}

--- a/src/test/java/org/avarion/yaml/testClasses/PartialRecordClass.java
+++ b/src/test/java/org/avarion/yaml/testClasses/PartialRecordClass.java
@@ -1,0 +1,27 @@
+package org.avarion.yaml.testClasses;
+
+import org.avarion.yaml.YamlFile;
+import org.avarion.yaml.YamlFileInterface;
+import org.avarion.yaml.YamlKey;
+
+/**
+ * A record inside a record, both with defaults — the shape a plugin uses for a
+ * credentials block: which engine, and how to log in to it.
+ */
+@YamlFile
+public class PartialRecordClass extends YamlFileInterface {
+
+    public enum Engine {MYSQL, H2}
+
+    public record Credentials(String hostname, int port, String password) {
+    }
+
+    public record Database(Engine engine, Credentials mysql) {
+    }
+
+    @YamlKey("database")
+    public Database database = new Database(Engine.MYSQL, new Credentials("db.default", 3306, "secret"));
+
+    @YamlKey("unrelated")
+    public String unrelated = "untouched";
+}

--- a/src/test/java/org/avarion/yaml/testClasses/RenamedKeyClass.java
+++ b/src/test/java/org/avarion/yaml/testClasses/RenamedKeyClass.java
@@ -1,0 +1,23 @@
+package org.avarion.yaml.testClasses;
+
+import org.avarion.yaml.YamlFile;
+import org.avarion.yaml.YamlFileInterface;
+import org.avarion.yaml.YamlKey;
+
+/**
+ * Fields whose keys have moved, each declaring where it used to live.
+ */
+@YamlFile
+public class RenamedKeyClass extends YamlFileInterface {
+
+    @YamlKey(value = "storm.damage-per-second", previously = "zone.damage-per-second")
+    public double damage = 1.0;
+
+    /** Two moves in its history; the file may still be at either one. */
+    @YamlKey(value = "hud.boss-bar.colour", previously = {"zone.bar.colour", "bar.colour"})
+    public String colour = "RED";
+
+    /** Never moved, so it must be left entirely alone. */
+    @YamlKey("game.hub-world")
+    public String hubWorld = "hub";
+}


### PR DESCRIPTION
Four changes, each its own commit, driven by two production incidents in the Avarion monorepo: a database that lost its credentials to a routine upgrade, and a server that ran years-stale loot tables. Both come back to the same thing — the library maps a file onto fields and has no way to express anything *about* a key, so a key that moves or a default that improves cannot be handled at all.

## What is in here

### 1. `fix: a record component the file leaves out keeps its default`

A key the file omits leaves its field alone. That rule stopped at a record's edge: a block the file mentioned *at all* was taken whole, so every component not named in it came out `null` — or, when the component was a primitive, refused to load the file.

```yaml
database:
  mysql:
    hostname: db.internal
```

...gave `Database(engine=null, mysql=Credentials("db.internal", …))`, silently. Add one missing primitive and it threw instead.

Components the YAML does not mention now keep whatever the target already held, which for a settings class is the compile-time default. **A key that IS present and empty is untouched by this** — writing nothing down and writing down nothing are different statements, so an explicit null still means null and still refuses to go into a primitive.

Two existing tests moved with the rule. Both fed a file whose component keys the class does not recognise and asserted the components came out null; they now assert the defaults stand, which is what an unrecognised key does everywhere else. I strengthened one of them while I was there — it had been asserting values that happened to equal the defaults, so it could not tell "read from file" from "kept default".

This one is a prerequisite for the rest: a block that moves into a record which has since grown a component is exactly the incident, and without this fix the migration would produce a half-null record.

### 2. `feat: declare where a setting used to live, and it moves itself`

```java
// one key
@YamlKey(value = "storm.damage-per-second", previously = "zone.damage-per-second")
public double damage = 1.0;

// a whole block — the case no field-level alias can reach
@YamlFile
@YamlRename(from = "mysql", to = "database.mysql")
public class Settings extends YamlFileInterface { … }
```

Both are applied to the parsed data map *before* any field reads it, so the field loads from the key it lives under now and a following `save` persists it there. That makes it a real migration rather than a read-through: a release or two later the declaration is deletable, because every file in the wild has already moved.

`@YamlRename` is repeatable and exists because the flagship case has no single field to hang an alias on — the field is a whole `DatabaseSettings` record and only its `mysql` component moved.

Rules, all tested:

| Situation | What happens |
|---|---|
| only the old key is set | value carried across, logged |
| only the current key is set | nothing, silently |
| both set | current key wins, out loud; old one dropped |
| old key set but empty | nothing — an empty line is not a value to carry |
| destination path blocked by a value | move refused, out loud, old key left where it is |

That last row matters: if something on the way to the destination is already a value rather than a section, forcing the move would destroy one setting to rescue another. It refuses instead, and leaves the old key in place so a caller watching for orphaned keys can still report it.

`renamesApplied()` reports what the load did — each declared old path mapped to the key that now holds its value, whether it was carried there or the current key was already set and won. Either way the key was *accounted for*, which is what lets a caller tell a handled move apart from a setting that vanished for no reason. The monorepo uses it to keep its drift warning quiet about migrations that worked.

Also drops `loadFields`' null-data guard and one `getConvertedValue` overload, both unreachable once `load(File)` normalises the parsed map.

### 3. `feat: let a caller say which keys the file must not supply`

The mirror of a rename. A file beats the compile-time default for every key it has — which is what an operator's choice should do, and is also why a default that *improves* between releases never reaches anybody whose file already mentions it. Their copy of last release's default outranks this release's, forever, and nothing distinguishes it from a value they chose deliberately.

Distinguishing them needs to know what the older default was. **That is the caller's business, not this library's** — deliberately. Acting on the answer is `load(File, Set<String>)`: the named keys are not read, so their fields keep what they already hold, and the write-back persists that.

`declaredKeys()` reports the units to name them in. A field is what reads the file, and a field may own a whole block, so ignoring one takes the block with it — half a block from the file and half from the defaults is a shape no class is written to expect.

Ignores are applied **after** renames. The other order would let a declared move put back a value the caller just excluded.

### 4. `fix: an inherited setting is written back, not silently dropped`

Found while building the above, and it is a genuine data-loss bug independent of everything else. Reading walked the class hierarchy; writing looked only at the class itself. A field a settings class *inherits* was loaded from the file and then left out of the file that replaced it, so one load-then-save cycle deleted the setting and whatever the operator had put in it.

Writing now walks the same hierarchy reading does. Two fields claiming one key still raise `DuplicateKey`, which is the right answer to a base class and a subclass both trying to own a setting.

## Compatibility

**Everything here is additive at the API level.** I was told I could break signatures freely if it made upgrades work better; I did not find a case where it would, so `load(File)`, `save(File)` and the annotations all keep their shapes. Existing call sites compile and behave identically.

What an outside consumer *would* notice, since this is published on CodeMC:

- **Records behave differently, and better** (change 1). A partial record block used to null out or throw; it now fills the gaps from whatever the target held. A **complete** block behaves exactly as before, so any config that was already valid is unaffected. Code that relied on partial blocks producing `null` — which was never a documented behaviour and reads as a bug — would see defaults instead.
- **Inherited fields now appear in written output** (change 4). Anyone using inheritance was silently losing those keys, so this is a fix; but if someone has a base class with `@YamlKey` fields they never wanted persisted, their emitted files will grow those keys. A field with no `@YamlKey` is still never persisted.
- **A class where a subclass and its base declare the same key now throws `DuplicateKey` on save**, where before the base's field was silently ignored on the write side.
- Two package-private members changed shape (`keyOf`, `TypeConverter.getConvertedValue`); neither is public API.

No behaviour changes for anyone not using records with partial blocks or `@YamlKey` on inherited fields.

## Version

The monorepo change that consumes this pins **`org.avarion:yaml:2.3.0`** — a minor bump, since the additions are additive and the record change is a fix. It needs tagging and releasing before that PR's CI can go green; I verified locally against a `2.3.0` published to `mavenLocal`.

## Testing

`307 → 319` tests, `failures=0 errors=0 skipped=0`, run against **both** SnakeYAML majors (`1.14` and `-PsnakeYamlVersion=2.5`) — identical results.

Line **and** branch coverage is 100% on every file this touches: `KeyRenames`, `YamlFileInterface`, `TypeConverter`. Reaching the last few branches meant deleting two pieces of genuinely unreachable defensive code rather than writing tests that could never fail, which I think is the right trade.

## What I did not do

- **No `previously` on record components.** A component's key lives inside its record's block, so a move into or out of that block is a change to the block — which `@YamlRename` already expresses. Adding a second, weaker spelling for the same thing did not seem worth it. Documented as a limitation.
- **No orphan-key reporting.** The library could report file keys that belong to no field, with `Similarity` suggesting the nearest declared key for typos. It is a genuinely nice idea and `declaredKeys()` now makes it cheap, but the monorepo already covers the essential case from outside and I did not want to widen this PR further.
- **No unknown-key rejection.** Making an unclaimed key fatal punishes operators at 6am for our renames.
